### PR TITLE
Add Flake8 Linting of Source Code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.6.4"
 
+cache: pip
+
 install:
   - pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - pip freeze
 
 script:
-  - flake8 --exclude demo
+  - flake8 --exclude demo  --max-line-length 80
   - coverage run -m unittest
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ python:
 install:
   - pip install -r requirements.txt
 
+before_script:
+  - pip --version
+  - pip freeze
+
 script:
-  coverage run -m unittest
+  - flake8 --exclude demo
+  - coverage run -m unittest
 
 after_success:
   - codecov

--- a/irishep/app.py
+++ b/irishep/app.py
@@ -28,6 +28,7 @@
 
 from pyspark import SparkContext
 
+
 class App:
-    def __init__(self, master="local", appName="spark-hep"):
-        self.sc = SparkContext(master=master, appName=appName)
+    def __init__(self, master="local", app_name="spark-hep"):
+        self.sc = SparkContext(master=master, app_name=app_name)

--- a/irishep/tests/test_app.py
+++ b/irishep/tests/test_app.py
@@ -34,11 +34,12 @@ from irishep.app import App
 
 class TestApp(unittest.TestCase):
     def test_app_create(self):
-        with patch('pyspark.SparkContext.__init__', return_value=None) as mock_spark:
+        with patch('pyspark.SparkContext.__init__',
+                   return_value=None) as mock_spark:
             a = App()
             self.assertTrue(a.sc)
-            mock_spark.assert_called_with(appName='spark-hep', master='local')
+            mock_spark.assert_called_with(app_name='spark-hep', master='local')
 
             mock_spark.clear()
-            App(appName="foo", master="spark-master")
-            mock_spark.assert_called_with(appName='foo', master='spark-master')
+            App(app_name="foo", master="spark-master")
+            mock_spark.assert_called_with(app_name='foo', master='spark-master')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyspark==2.4.0
 coverage==4.5.2
 codecov==2.0.15
+flake8==3.7.7


### PR DESCRIPTION
# Problem 
The PEP8 standard encourages good Python coding practices. Without a linting step in the CI pipeline it's hard to enforce these rules consistently

# Approach 
Added a flake8 step to `travis.yaml` - it skips over the `demo` folder since that is where
examples and half-baked tests live.

I set the `max_line_length` to 80 to match PyCharm