### PR TITLE
#2 Query Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,24 @@ physics data.
 [![Build Status](https://travis-ci.org/BenGalewsky/spark-hep-query.svg?branch=master)](https://travis-ci.org/BenGalewsky/spark-hep-query)
 [![codecov](https://codecov.io/gh/BenGalewsky/spark-hep-query/branch/master/graph/badge.svg)](https://codecov.io/gh/BenGalewsky/spark-hep-query)
 
+## Application
+The main entrypoint for the query service is through an instance of the `App` 
+class.  It is constructed from a `Config` object specification.
+
+## Dataset Management
+We don't want analyzers to have to think about individual ROOT files. 
+Consequently we hide them behind a `Dataset` abstraction. While we can imagine 
+more sophisticated implementations, our first draft for testing and development 
+relies on a local csv file with dataset names and paths to the files. A 
+dataset can be composed of multiple files. This is represented as rows sharing 
+the same dataset name.
+
+An instance of the dataset manager is created as part of the `config` object 
+and passed into the application initializer.
+
+The first operation on this dataset manager just returns a list with each of 
+the dataset names.
+
 ## How to Test
 We use `unittest` to verify the system. Run the tests as 
 ```bash

--- a/demo/datasets.py
+++ b/demo/datasets.py
@@ -26,27 +26,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from irishep.config import Config
+from irishep.datasets.files_dataset_manager import FilesDatasetManager
+from irishep.app import App
 
-class Config:
-    """
-    Specification of spark query service configuration options.
+config = Config(
+    dataset_manager=FilesDatasetManager(database_file="demo_datasets.csv")
+)
+app = App(config=config)
+print(app.datasets.get_names())
 
-    Parameters
-    ----------
-        local_dataset_file: String path expression, optional
-            Path to a csv file holding the names of datasets and their location
-            on the local filesystem
-        master: String, optional
-            Reference to spark master. Defaults to local
-        app_name: String, optional
-            String name that will be passed to spark to reference this
-            application
-    """
-    def __init__(self,
-                 dataset_manager=None,
-                 master="local",
-                 app_name="spark-hep"):
-
-        self.dataset_manager = dataset_manager
-        self.master = master
-        self.app_name = app_name

--- a/demo/demo_datasets.csv
+++ b/demo/demo_datasets.csv
@@ -1,0 +1,9 @@
+name,path
+"DY Jets", DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.root
+"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_40.root
+"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_41.root
+"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_42.root
+"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_43.root
+"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_44.root
+"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_45.root
+"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_46.root

--- a/irishep/app.py
+++ b/irishep/app.py
@@ -27,9 +27,24 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from pyspark import SparkContext
+from pyspark.sql import SparkSession
 
 
 class App:
     def __init__(self, config):
-        self.sc = SparkContext(master=config.master, appName=config.app_name)
+        self.spark = SparkSession.builder \
+            .master(config.master) \
+            .appName(config.app_name) \
+            .getOrCreate()
+
+        self.dataset_manager = config.dataset_manager
+
+    @property
+    def datasets(self):
+        """
+        Fetch an initialized dataset manager instance
+        :return: the dataset manager instance
+        """
+        if not self.dataset_manager.provisioned:
+            self.dataset_manager.provision(self)
+        return self.dataset_manager

--- a/irishep/config.py
+++ b/irishep/config.py
@@ -27,9 +27,26 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from pyspark import SparkContext
+class Config:
+    """
+    Specification of spark query service configuration options.
 
+    Parameters
+    ----------
+        local_dataset_file: String path expression, optional
+            Path to a csv file holding the names of datasets and their location
+            on the local filesystem
+        master: String, optional
+            Reference to spark master. Defaults to local
+        app_name: String, optional
+            String name that will be passed to spark to reference this
+            application
+    """
+    def __init__(self,
+                 local_dataset_file=None,
+                 master="local",
+                 app_name="spark-hep"):
 
-class App:
-    def __init__(self, config):
-        self.sc = SparkContext(master=config.master, appName=config.app_name)
+        self.local_dataset_file = local_dataset_file
+        self.master = master
+        self.app_name = app_name

--- a/irishep/datasets/__init__.py
+++ b/irishep/datasets/__init__.py
@@ -25,28 +25,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-class Config:
-    """
-    Specification of spark query service configuration options.
-
-    Parameters
-    ----------
-        local_dataset_file: String path expression, optional
-            Path to a csv file holding the names of datasets and their location
-            on the local filesystem
-        master: String, optional
-            Reference to spark master. Defaults to local
-        app_name: String, optional
-            String name that will be passed to spark to reference this
-            application
-    """
-    def __init__(self,
-                 dataset_manager=None,
-                 master="local",
-                 app_name="spark-hep"):
-
-        self.dataset_manager = dataset_manager
-        self.master = master
-        self.app_name = app_name

--- a/irishep/datasets/dataset_manager.py
+++ b/irishep/datasets/dataset_manager.py
@@ -26,27 +26,22 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from abc import ABCMeta, abstractmethod
 
-class Config:
-    """
-    Specification of spark query service configuration options.
 
-    Parameters
-    ----------
-        local_dataset_file: String path expression, optional
-            Path to a csv file holding the names of datasets and their location
-            on the local filesystem
-        master: String, optional
-            Reference to spark master. Defaults to local
-        app_name: String, optional
-            String name that will be passed to spark to reference this
-            application
-    """
-    def __init__(self,
-                 dataset_manager=None,
-                 master="local",
-                 app_name="spark-hep"):
+class DatasetManager(metaclass=ABCMeta):
+    @abstractmethod
+    def provision(self, app):
+        """
+        Take whatever steps to provision the dataset manager. This is done
+        after the application has been initialized
+        :param app: The initialized Query Service App
+        :return: None
+        """
 
-        self.dataset_manager = dataset_manager
-        self.master = master
-        self.app_name = app_name
+    @abstractmethod
+    def get_names(self):
+        """
+        Get the list of dataset names served up by this manager
+        :return: List of dataset names
+        """

--- a/irishep/datasets/files_dataset_manager.py
+++ b/irishep/datasets/files_dataset_manager.py
@@ -25,28 +25,39 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from irishep.datasets.dataset_manager import DatasetManager
 
 
-class Config:
+class FilesDatasetManager(DatasetManager):
     """
-    Specification of spark query service configuration options.
+    Dataset manager that is backed by a csv file. The file must contain entries
+    for each file associated with datasets.
 
-    Parameters
-    ----------
-        local_dataset_file: String path expression, optional
-            Path to a csv file holding the names of datasets and their location
-            on the local filesystem
-        master: String, optional
-            Reference to spark master. Defaults to local
-        app_name: String, optional
-            String name that will be passed to spark to reference this
-            application
+    The format of the file is:
+    name, path
+    Where "name" is the dataset name, and "path" is the path to the underlying
+    file. Datasets can be made up of multiple files. This is represented by
+    mulitple entries sharing the same name.
     """
-    def __init__(self,
-                 dataset_manager=None,
-                 master="local",
-                 app_name="spark-hep"):
+    def __init__(self, database_file):
+        self.database_file = database_file
+        self.provisioned = False
 
-        self.dataset_manager = dataset_manager
-        self.master = master
-        self.app_name = app_name
+    def provision(self, app):
+        """
+        Provision the manager after the app has been set up by reading the csv
+        file and storing the resulting dataframe
+        :param app: The initialized Query Service App
+        :return: None
+        """
+        self.dataframe = app.spark.read.csv(self.database_file, header=True)
+        self.provisioned = True
+        return self
+
+    def get_names(self):
+        """
+        return the names of the datasets in the database
+        :return: list of dataset names
+        """
+        distinct_names = self.dataframe.select(self.dataframe.name).distinct()
+        return [r.name for r in distinct_names.collect()]

--- a/irishep/datasets/tests/__init__.py
+++ b/irishep/datasets/tests/__init__.py
@@ -25,28 +25,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-class Config:
-    """
-    Specification of spark query service configuration options.
-
-    Parameters
-    ----------
-        local_dataset_file: String path expression, optional
-            Path to a csv file holding the names of datasets and their location
-            on the local filesystem
-        master: String, optional
-            Reference to spark master. Defaults to local
-        app_name: String, optional
-            String name that will be passed to spark to reference this
-            application
-    """
-    def __init__(self,
-                 dataset_manager=None,
-                 master="local",
-                 app_name="spark-hep"):
-
-        self.dataset_manager = dataset_manager
-        self.master = master
-        self.app_name = app_name


### PR DESCRIPTION
# Problem
Fixes #2 
Users need to be able to see a list of valid datasets available through the platform.

# Approach
- Created an abstract base class for DatasetManagers.
- Created a simple subclass that reads datasets from a local csv file
- Added a method to the app class for reading a list of dataset names
- Added a config class for setting up the application and selecting a dataset manager
