### PR TITLE
Ability to Load a Dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ the same dataset name.
 An instance of the dataset manager is created as part of the `config` object 
 and passed into the application initializer.
 
-The first operation on this dataset manager just returns a list with each of 
-the dataset names.
+### Reading a Dataset into Memory
+Once you have a dataset name, you can provide it to the application object to 
+have all of the assoicated files loaded into the cluster for analysis. 
+
+Use the `read_dataset` method on the `App` object with the dataset name. You 
+will receieve a `Dataset` object which represents all of the events. We have
+implemented a `count` method on the dataset to return the number of events.
 
 ## How to Test
 We use `unittest` to verify the system. Run the tests as 

--- a/demo/datasets.py
+++ b/demo/datasets.py
@@ -36,3 +36,6 @@ config = Config(
 app = App(config=config)
 print(app.datasets.get_names())
 
+dataset = app.read_dataset("ZJetsToNuNu_HT-600To800_13TeV-madgraph")
+print(dataset.name, dataset.count())
+

--- a/demo/demo_datasets.csv
+++ b/demo/demo_datasets.csv
@@ -1,9 +1,4 @@
 name,path
-"DY Jets", DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.root
-"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_40.root
-"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_41.root
-"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_42.root
-"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_43.root
-"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_44.root
-"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_45.root
-"ZJetsToNuNu_HT-600To800_13TeV-madgraph", nano_46.root
+"DY Jets",file:/Users/bengal1/dev/IRIS-HEP/data/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.root
+"ZJetsToNuNu_HT-600To800_13TeV-madgraph",file:/Users/bengal1/dev/IRIS-HEP/data/nano_115.root
+"ZJetsToNuNu_HT-600To800_13TeV-madgraph",file:/Users/bengal1/dev/IRIS-HEP/data/nano_50.root

--- a/irishep/datasets/dataset.py
+++ b/irishep/datasets/dataset.py
@@ -26,30 +26,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from abc import ABCMeta, abstractmethod
 
+class Dataset:
+    def __init__(self, name, dataframe):
+        self.name = name
+        self.dataframe = dataframe
 
-class DatasetManager(metaclass=ABCMeta):
-    @abstractmethod
-    def provision(self, app):
-        """
-        Take whatever steps to provision the dataset manager. This is done
-        after the application has been initialized
-        :param app: The initialized Query Service App
-        :return: None
-        """
-
-    @abstractmethod
-    def get_names(self):
-        """
-        Get the list of dataset names served up by this manager
-        :return: List of dataset names
-        """
-
-    @abstractmethod
-    def get_file_list(self, dataset_name):
-        """
-        Find the paths to the files associated with the given dataset name
-        :param dataset_name:
-        :return: list of string pathnames
-        """
+    def count(self):
+        return self.dataframe.count()

--- a/irishep/datasets/files_dataset_manager.py
+++ b/irishep/datasets/files_dataset_manager.py
@@ -50,7 +50,7 @@ class FilesDatasetManager(DatasetManager):
         :param app: The initialized Query Service App
         :return: None
         """
-        self.dataframe = app.spark.read.csv(self.database_file, header=True)
+        self.df = app.spark.read.csv(self.database_file, header=True)
         self.provisioned = True
         return self
 
@@ -59,5 +59,10 @@ class FilesDatasetManager(DatasetManager):
         return the names of the datasets in the database
         :return: list of dataset names
         """
-        distinct_names = self.dataframe.select(self.dataframe.name).distinct()
+        distinct_names = self.df.select(self.df.name).distinct()
         return [r.name for r in distinct_names.collect()]
+
+    def get_file_list(self, dataset_name):
+        paths = self.df.select(self.df.path).filter(
+            self.df.name == dataset_name)
+        return [r.path for r in paths.collect()]

--- a/irishep/datasets/tests/test_dataset.py
+++ b/irishep/datasets/tests/test_dataset.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import Mock
+
+import pyspark.sql
+
+from irishep.datasets.dataset import Dataset
+
+
+class TestDataset(unittest.TestCase):
+    def test_constuctor(self):
+        mock_dataframe = Mock(pyspark.sql.DataFrame)
+        a_dataset = Dataset("my dataset", mock_dataframe)
+        self.assertEqual(a_dataset.name, "my dataset")
+        self.assertEqual(a_dataset.dataframe, mock_dataframe)
+
+    def test_count(self):
+        mock_dataframe = Mock(pyspark.sql.DataFrame)
+        mock_dataframe.count = Mock(return_value=42)
+        a_dataset = Dataset("my dataset", mock_dataframe)
+        count = a_dataset.count()
+        self.assertEqual(42, count)
+        mock_dataframe.count.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/irishep/tests/test_app.py
+++ b/irishep/tests/test_app.py
@@ -69,20 +69,12 @@ class TestApp(unittest.TestCase):
             return App(config)
 
     def test_provisioned_dataset_manager(self):
-        builder = pyspark.sql.session.SparkSession.Builder()
-        mock_session = MagicMock(SparkSession)
-        builder.getOrCreate = Mock(return_value=mock_session)
-
         mock_datasource_manager = Mock(DatasetManager)
         mock_datasource_manager.provisioned = True
         a = self._construct_app(Config(dataset_manager=mock_datasource_manager))
         self.assertTrue(a.datasets)
 
     def test_unprovisioned_dataset_manager(self):
-        builder = pyspark.sql.session.SparkSession.Builder()
-        mock_session = MagicMock(SparkSession)
-        builder.getOrCreate = Mock(return_value=mock_session)
-
         mock_datasource_manager = Mock(DatasetManager)
         mock_datasource_manager.provisioned = False
         mock_datasource_manager.provision = Mock()


### PR DESCRIPTION
# Problem
Users need to be able to load in all of the files associated with a given dataset. 
Fixes #3 

# Approach
Added new method to DatasetManager to retrieve the paths to each file that makes up a dataset. Use this to load the root files into a single spark Dataframe. Currently only support ROOT files. Spark-Root doesn't handle a list of paths, so I load each file separately and then us `union` operator to make one big Dataframe.

The Dataframe is wrapped as a new class I added `Dataset` which will be the handle physicist use to interact with the loaded dataset.

# To Test
Take a look at `demo/datasets.py`
