### PR TITLE
5 project dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,43 @@ An instance of the dataset manager is created as part of the `config` object
 and passed into the application initializer.
 
 ### Reading a Dataset into Memory
-Once you have a dataset name, you can provide it to the application object to 
-have all of the assoicated files loaded into the cluster for analysis. 
-
 Use the `read_dataset` method on the `App` object with the dataset name. You 
 will receieve a `Dataset` object which represents all of the events. We have
-implemented a `count` method on the dataset to return the number of events.
+implemented a `count` method on the dataset to return the number of events. 
+We automatically create a new constant column in the dataframe which holds the 
+dataset's name.
+
+### Slimming Dataset
+The number of columns in the analysis has a dramatic impact on performance since
+the dataframe is translated into a numpy array for processing in the 
+UDF. We remove columns with the `select_columns` operation on the dataframe. You 
+pass in only the column names needed for your analysis.
+
+For technical reasons we always want a few descriptive columns included in
+datasets. We will include these columns if they are not in the select 
+request. The columns currently are:
+* dataset
+* run
+* luminosityBlock
+* event
+
+For now, we are assuming that we are working with a CMS NanoAOD file. This 
+will need more flexibility as we gain experience with new file formats.
+
+### Dataset Operations
+There are some useful methods on dataset (which are mostly just passed
+through to Spark)
+
+`count` - Returns the number of events in the dataset
+
+`columns` - Returns a list of string column names
+
+`columns_with_types` - Returns a list of tuples with (column name, data type)
+ 
+`select_columns` - Returns a new dataframe with just the specified columns in it
+(along with a few automatically included columns required for technical reasons)
+
+`show` - Print to stdout a friendly table of the first few events
 
 ## How to Test
 We use `unittest` to verify the system. Run the tests as 

--- a/demo/datasets.py
+++ b/demo/datasets.py
@@ -41,3 +41,13 @@ print(dataset.name, dataset.count())
 print(dataset.columns)
 print (dataset.columns_with_types)
 
+slim = dataset.select_columns(["nElectron",
+                               "Electron_pt",
+                               "Electron_eta",
+                               "Electron_phi",
+                               "Electron_mass",
+                               "Electron_cutBased",
+                               "Electron_pdgId",
+                               "Electron_pfRelIso03_all"])
+
+print(slim.show())

--- a/demo/datasets.py
+++ b/demo/datasets.py
@@ -36,6 +36,8 @@ config = Config(
 app = App(config=config)
 print(app.datasets.get_names())
 
-dataset = app.read_dataset("ZJetsToNuNu_HT-600To800_13TeV-madgraph")
+dataset = app.read_dataset("DY Jets")
 print(dataset.name, dataset.count())
+print(dataset.columns)
+print (dataset.columns_with_types)
 

--- a/irishep/config.py
+++ b/irishep/config.py
@@ -33,9 +33,8 @@ class Config:
 
     Parameters
     ----------
-        local_dataset_file: String path expression, optional
-            Path to a csv file holding the names of datasets and their location
-            on the local filesystem
+        dataset_manager: DatasetManager, optional
+            Instance of dataset manager
         master: String, optional
             Reference to spark master. Defaults to local
         app_name: String, optional

--- a/irishep/datasets/dataset.py
+++ b/irishep/datasets/dataset.py
@@ -34,3 +34,11 @@ class Dataset:
 
     def count(self):
         return self.dataframe.count()
+
+    @property
+    def columns(self):
+        return self.dataframe.columns
+
+    @property
+    def columns_with_types(self):
+        return self.dataframe.dtypes

--- a/irishep/datasets/dataset.py
+++ b/irishep/datasets/dataset.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+# noinspection PyUnresolvedReferences
 from pyspark.sql.functions import lit
 
 
@@ -44,8 +45,37 @@ class Dataset:
 
     @property
     def columns(self):
+        """
+        Fetch the list of column names from the dataset
+        :return: List of string column names
+        """
         return self.dataframe.columns
 
     @property
     def columns_with_types(self):
+        """
+        Fetch the list of column names along with their datatypes
+        :return: List of tuples with column name and datatype as string
+        """
         return self.dataframe.dtypes
+
+    def select_columns(self, columns):
+        """
+        Create a new dataset object that contains only the specified columns.
+        For techincal reasons there are some identifying columns that will
+        be included in the result even if they are not requested
+        :param columns: List of column names
+        :return: New dataframe with only the requested columns
+        """
+        columns2 = set(columns).union(
+            ["dataset", "run", "luminosityBlock", "event"])
+
+        return Dataset(name=self.name,
+                       dataframe=self.dataframe.select(list(columns2)))
+
+    def show(self):
+        """
+        Print out a friendly representation of the dataframe
+        :return: None
+        """
+        self.dataframe.show()

--- a/irishep/datasets/dataset.py
+++ b/irishep/datasets/dataset.py
@@ -27,10 +27,17 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+from pyspark.sql.functions import lit
+
+
 class Dataset:
     def __init__(self, name, dataframe):
         self.name = name
-        self.dataframe = dataframe
+
+        if 'dataset' not in dataframe.columns:
+            self.dataframe = dataframe.withColumn("dataset", lit(name))
+        else:
+            self.dataframe = dataframe
 
     def count(self):
         return self.dataframe.count()

--- a/irishep/datasets/files_dataset_manager.py
+++ b/irishep/datasets/files_dataset_manager.py
@@ -42,6 +42,7 @@ class FilesDatasetManager(DatasetManager):
     def __init__(self, database_file):
         self.database_file = database_file
         self.provisioned = False
+        self.df = None
 
     def provision(self, app):
         """

--- a/irishep/datasets/tests/test_dataset.py
+++ b/irishep/datasets/tests/test_dataset.py
@@ -21,6 +21,20 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(42, count)
         mock_dataframe.count.assert_called_once()
 
+    def test_columns(self):
+        mock_dataframe = Mock(pyspark.sql.DataFrame)
+        mock_dataframe.columns = ['a','b','c']
+        a_dataset = Dataset("my dataset", mock_dataframe)
+        cols = a_dataset.columns
+        self.assertEqual(cols, ['a','b','c'])
+
+    def test_columns_with_types(self):
+        mock_dataframe = Mock(pyspark.sql.DataFrame)
+        mock_dataframe.dtypes = [('a', 'int'),('b', 'string')]
+        a_dataset = Dataset("my dataset", mock_dataframe)
+        cols = a_dataset.columns_with_types
+        self.assertEqual(cols, [('a', 'int'),('b', 'string')])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/irishep/datasets/tests/test_files_dataset_manager.py
+++ b/irishep/datasets/tests/test_files_dataset_manager.py
@@ -33,7 +33,7 @@ from pyspark.sql import DataFrame
 from irishep.datasets.files_dataset_manager import FilesDatasetManager
 
 
-class Test_FilesDataset(unittest.TestCase):
+class TestFilesDataset(unittest.TestCase):
     class DatasourceResult:
         def __init__(self, name, path="/tmp/foo.root"):
             self.name = name
@@ -62,8 +62,8 @@ class Test_FilesDataset(unittest.TestCase):
         mock_dataframe.select = Mock(return_value=mock_dataframe)
         mock_dataframe.distinct = Mock(return_value=mock_dataframe)
 
-        result = [Test_FilesDataset.DatasourceResult("a"),
-                  Test_FilesDataset.DatasourceResult("b")]
+        result = [TestFilesDataset.DatasourceResult("a"),
+                  TestFilesDataset.DatasourceResult("b")]
         mock_dataframe.collect = Mock(return_value=result)
         self.assertEqual(['a', 'b'], dsm.get_names())
 
@@ -77,8 +77,8 @@ class Test_FilesDataset(unittest.TestCase):
         mock_dataframe.path = "path"
         mock_dataframe.name = "a"
 
-        result = [Test_FilesDataset.DatasourceResult("a", "/tmp/foo.root"),
-                  Test_FilesDataset.DatasourceResult("b", "/tmp/bar.root")]
+        result = [TestFilesDataset.DatasourceResult("a", "/tmp/foo.root"),
+                  TestFilesDataset.DatasourceResult("b", "/tmp/bar.root")]
         mock_dataframe.collect = Mock(return_value=result)
 
         files = dsm.get_file_list("a")

--- a/irishep/tests/test_app.py
+++ b/irishep/tests/test_app.py
@@ -61,7 +61,8 @@ class TestApp(unittest.TestCase):
             builder.getOrCreate.assert_called_once()
             self.assertEqual(a.dataset_manager, mock_dataset_manager)
 
-    def _construct_app(self, config):
+    @staticmethod
+    def _construct_app(config):
         builder = pyspark.sql.session.SparkSession.Builder()
         mock_session = MagicMock(SparkSession)
         builder.getOrCreate = Mock(return_value=mock_session)

--- a/irishep/tests/test_app.py
+++ b/irishep/tests/test_app.py
@@ -101,6 +101,7 @@ class TestApp(unittest.TestCase):
         # The first dataframe will be union'ed with the second, resulting in a
         # new dataframe
         mock_union_dataframe = Mock(pyspark.sql.DataFrame)
+        mock_union_dataframe.columns = ['dataset', 'a', 'b']
         mock_file_dataframes[0].union = Mock(return_value=mock_union_dataframe)
 
         # Perform the read


### PR DESCRIPTION
# Problem
Fixes #5 
The columnar analytic approach needs the datasets to be as _slim_ as possible since each data column must be translated from the JVM into the python numpy array. Users need to be able to remove unnecessary  from the data frame.

# Aproach
Added a new operation on dataset `select_columns` which allow users to generate a new dataset with only the selected columns in it.

It is useful as we work with multiple datasets to be able to keep track of which dataset each event belongs to. Added code to the dataset init method to create a new column which contains this. This needs to be preserved across selects, along with eventID and some other identifying information. The `select_columns` operation automatically includes them if they are not in the user's request.

Added some handy new operations on Dataset to make it easier to work with them. 