### PR TITLE
Run User Analysis with Physics Objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - pip freeze
 
 script:
-  - flake8 --exclude demo  --max-line-length 80
+  - flake8 --exclude demo,templates  --max-line-length 80
   - coverage run -m unittest
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ through to Spark)
 
 `show` - Print to stdout a friendly table of the first few events
 
+## User Defined Analysis
+Once you get a projected dataset you will want to execute your columnar analysis
+on the events. To do this you will want to implement a subclass of 
+`UserAnalysis` class. You will implement a single method, `calc` - this
+method will accept a dictionary of JaggedArrays. The keys in this dictionary
+are Physics Object names.
+
+You invoke this UDF by creating an instance of `NanoAODColumnarAnalysis`. This
+class makes assumptions about the CMS NanoAOD file format. Then call
+`generate_udf` with your projected dataset, the list of physics_objects you
+need to operate on, your code to execute on the return, and a fully 
+qualified analysis class name.
+
+
 ## How to Test
 We use `unittest` to verify the system. Run the tests as 
 ```bash

--- a/demo/zpeak/__init__.py
+++ b/demo/zpeak/__init__.py
@@ -25,38 +25,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from irishep.config import Config
-from irishep.datasets.files_dataset_manager import FilesDatasetManager
-from irishep.app import App
-
-config = Config(
-    dataset_manager=FilesDatasetManager(database_file="demo_datasets.csv")
-)
-app = App(config=config)
-print(app.datasets.get_names())
-
-dataset = app.read_dataset("DY Jets")
-print(dataset.name, dataset.count())
-print(dataset.columns)
-print (dataset.columns_with_types)
-
-slim = dataset.select_columns(["nElectron",
-                               "Electron_pt",
-                               "Electron_eta",
-                               "Electron_phi",
-                               "Electron_mass",
-                               "Electron_cutBased",
-                               "Electron_pdgId",
-                               "Electron_pfRelIso03_all",
-                               "nMuon",
-                               "Muon_pt",
-                               "Muon_eta",
-                               "Muon_phi",
-                               "Muon_mass",
-                               "Muon_tightId",
-                               "Muon_pdgId",
-                               "Muon_pfRelIso04_all"])
-
-
-print(slim.show())

--- a/demo/zpeak/zpeak_analysis.py
+++ b/demo/zpeak/zpeak_analysis.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import numpy as np
+
+from analysis.user_analysis import UserAnalysis
+
+
+class ZpeakAnalysis(UserAnalysis):
+
+    @staticmethod
+    def calc(physics_objects):
+        electrons = physics_objects["Electron"]
+        ele = electrons[(electrons.pt > 20) &
+                        (np.abs(electrons.eta) < 2.5) &
+                        (electrons.cutBased >= 4)]
+
+        muons = physics_objects["Muon"]
+        mu = muons[(muons.pt > 20) &
+                   (np.abs(muons.eta) < 2.4) &
+                   (muons.tightId > 0)]
+
+        ee = ele.distincts()
+        mm = mu.distincts()
+        em = ele.cross(mu)
+
+        dileptons = {}
+        dileptons['ee'] = ee[
+            (ee.i0.pdgId * ee.i1.pdgId == -11 * 11) & (ee.i0.pt > 25)]
+        dileptons['mm'] = mm[(mm.i0.pdgId * mm.i1.pdgId == -13 * 13)]
+        dileptons['em'] = em[(em.i0.pdgId * em.i1.pdgId == -11 * 13)]
+
+        channels = {}
+        channels['ee'] = (ee.counts == 1) & (mu.counts == 0)
+        channels['mm'] = (mm.counts == 1) & (ele.counts == 0)
+        channels['em'] = (em.counts == 1) & (ele.counts == 1) & (
+            mu.counts == 1)
+
+        # dupe = np.zeros(Muon_pt.size, dtype=bool)
+        tot = 0
+
+        isRealData = True
+        for channel, cut in channels.items():
+            zcands = dileptons[channel][cut]
+            # dupe |= cut
+            tot += cut.sum()
+            weight = np.array(1.)
+
+            # zMassHist = hists["zMass"]
+            #
+            # zMass = hist.Hist("Events", dataset_axis, channel_cat_axis,
+            #                   hist.Bin("mass", "$m_{\ell\ell}$ [GeV]", 120, 0, 120),
+            #                   )
+            #
+            # zMass.fill(dataset=dataset[0], channel=channel,
+            #            mass=zcands.mass.flatten(),
+            #            weight=weight.flatten())
+            # zMassHist.add(zMass)

--- a/demo/zpeak/zpeak_app.py
+++ b/demo/zpeak/zpeak_app.py
@@ -26,18 +26,21 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.types import DoubleType
+
+from analysis.nanoaod_columnar_analysis import NanoAODColumnarAnalysis
+from irishep.app import App
 from irishep.config import Config
 from irishep.datasets.files_dataset_manager import FilesDatasetManager
-from irishep.app import App
 
 config = Config(
-    dataset_manager=FilesDatasetManager(database_file="demo_datasets.csv")
+    dataset_manager=FilesDatasetManager(database_file="../demo_datasets.csv")
 )
 app = App(config=config)
 print(app.datasets.get_names())
 
 dataset = app.read_dataset("DY Jets")
-print(dataset.name, dataset.count())
 print(dataset.columns)
 print (dataset.columns_with_types)
 
@@ -58,5 +61,11 @@ slim = dataset.select_columns(["nElectron",
                                "Muon_pdgId",
                                "Muon_pfRelIso04_all"])
 
+analysis = NanoAODColumnarAnalysis()
 
-print(slim.show())
+f = analysis.generate_udf(slim, ["Electron", "Muon"], "pd.Series(np.ones(Electron_pt.size))", "demo.zpeak.zpeak_analysis.ZpeakAnalysis" )
+zpeak_udf = pandas_udf(f, DoubleType(), PandasUDFType.SCALAR)
+
+analysis = slim.dataframe.select(zpeak_udf(*slim.columns_for_physics_objects(["Electron", "Muon"])))
+
+analysis.show()

--- a/irishep/analysis/__init__.py
+++ b/irishep/analysis/__init__.py
@@ -25,38 +25,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from irishep.config import Config
-from irishep.datasets.files_dataset_manager import FilesDatasetManager
-from irishep.app import App
-
-config = Config(
-    dataset_manager=FilesDatasetManager(database_file="demo_datasets.csv")
-)
-app = App(config=config)
-print(app.datasets.get_names())
-
-dataset = app.read_dataset("DY Jets")
-print(dataset.name, dataset.count())
-print(dataset.columns)
-print (dataset.columns_with_types)
-
-slim = dataset.select_columns(["nElectron",
-                               "Electron_pt",
-                               "Electron_eta",
-                               "Electron_phi",
-                               "Electron_mass",
-                               "Electron_cutBased",
-                               "Electron_pdgId",
-                               "Electron_pfRelIso03_all",
-                               "nMuon",
-                               "Muon_pt",
-                               "Muon_eta",
-                               "Muon_phi",
-                               "Muon_mass",
-                               "Muon_tightId",
-                               "Muon_pdgId",
-                               "Muon_pfRelIso04_all"])
-
-
-print(slim.show())

--- a/irishep/analysis/columnar_analysis.py
+++ b/irishep/analysis/columnar_analysis.py
@@ -25,38 +25,25 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from irishep.config import Config
-from irishep.datasets.files_dataset_manager import FilesDatasetManager
-from irishep.app import App
-
-config = Config(
-    dataset_manager=FilesDatasetManager(database_file="demo_datasets.csv")
-)
-app = App(config=config)
-print(app.datasets.get_names())
-
-dataset = app.read_dataset("DY Jets")
-print(dataset.name, dataset.count())
-print(dataset.columns)
-print (dataset.columns_with_types)
-
-slim = dataset.select_columns(["nElectron",
-                               "Electron_pt",
-                               "Electron_eta",
-                               "Electron_phi",
-                               "Electron_mass",
-                               "Electron_cutBased",
-                               "Electron_pdgId",
-                               "Electron_pfRelIso03_all",
-                               "nMuon",
-                               "Muon_pt",
-                               "Muon_eta",
-                               "Muon_phi",
-                               "Muon_mass",
-                               "Muon_tightId",
-                               "Muon_pdgId",
-                               "Muon_pfRelIso04_all"])
+from abc import ABCMeta, abstractmethod
 
 
-print(slim.show())
+class ColumnarAnalysis(metaclass=ABCMeta):
+    def __init__(self):
+        """
+        Base class for a columnar style analysis
+        """
+
+    @abstractmethod
+    def generate_udf(self, dataset, physics_objects, return_expr,
+                     analysis_class):
+        """
+        Create a function that implements a spark Pandas UDF
+        :param dataset: Dataset object that this analysis will run over
+        :param physics_objects: List of physics object names
+        :param return_expr: A string representing what you want to return from
+        the UDF
+        :param analysis_class: Fully qualified class name for a subclass of
+        user_analysis class
+        :return: The generated function
+        """

--- a/irishep/analysis/nanoaod_columnar_analysis.py
+++ b/irishep/analysis/nanoaod_columnar_analysis.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from irishep.analysis.columnar_analysis import ColumnarAnalysis
+from jinja2 import Environment, PackageLoader, select_autoescape
+import re
+
+
+class NanoAODColumnarAnalysis(ColumnarAnalysis):
+    obj_property_re = re.compile("^[A-Za-z0-9]+_(.*)")
+
+    def __init__(self):
+        super().__init__()
+        self.env = Environment(
+            loader=PackageLoader('irishep', 'templates'),
+            autoescape=select_autoescape(['py'])
+        )
+
+    def _zip_entry(self, col_name):
+        """
+        Create a jagged array entry for zipping. This is where we convert the
+        pandas Series to a jagged array
+        :param col_name: Column Name
+        :return: String that represents an entry in JaggedArray.zip for
+        that column
+        """
+        match = re.match(self.obj_property_re, col_name)
+        item = '{}={}.array[0].base'.format(match.group(1), col_name)
+        return item
+
+    def generate_udf(self, dataset, physics_objects, return_expr,
+                     analysis_class):
+        """
+        Create a pandas dataframe UDF that can be passed into spark for
+        implementing the analysis.
+        :param dataset: The dataset this analysis is based on
+        :param physics_objects: List of physics object names that will be passed
+        into the UDF
+        :param return_expr: Code to execute to return value from UDF
+        :param analysis_class: Fully qualified class name for a subclass of
+        user_analysis class
+        :return: The generated function
+        """
+
+        # Create a directory of JaggedArray zip entries. One for each physics
+        # object. Each entry in the dictionary is a list of zip entries. The
+        # zip entries include one for the count series (i.e. nElectron)
+        objects = {o:
+                   ["{}.array".format(
+                       dataset.count_column_for_physics_object(o))] +
+                   [
+                       self._zip_entry(c) for c in dataset.columns if
+                       c.startswith(o + "_")
+                   ] for o in physics_objects
+                   }
+
+        template = self.env.get_template('mytemplate.py')
+        udf_str = template.render(physics_objects=objects,
+                                  cols=dataset.columns_for_physics_objects(
+                                      physics_objects),
+                                  return_expr=return_expr,
+                                  analysis_class=analysis_class)
+        print(udf_str)
+        exec(udf_str)
+
+        # Assume that the template renders to a def udf(....)
+        return locals()['udf']

--- a/irishep/analysis/tests/__init__.py
+++ b/irishep/analysis/tests/__init__.py
@@ -25,38 +25,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from irishep.config import Config
-from irishep.datasets.files_dataset_manager import FilesDatasetManager
-from irishep.app import App
-
-config = Config(
-    dataset_manager=FilesDatasetManager(database_file="demo_datasets.csv")
-)
-app = App(config=config)
-print(app.datasets.get_names())
-
-dataset = app.read_dataset("DY Jets")
-print(dataset.name, dataset.count())
-print(dataset.columns)
-print (dataset.columns_with_types)
-
-slim = dataset.select_columns(["nElectron",
-                               "Electron_pt",
-                               "Electron_eta",
-                               "Electron_phi",
-                               "Electron_mass",
-                               "Electron_cutBased",
-                               "Electron_pdgId",
-                               "Electron_pfRelIso03_all",
-                               "nMuon",
-                               "Muon_pt",
-                               "Muon_eta",
-                               "Muon_phi",
-                               "Muon_mass",
-                               "Muon_tightId",
-                               "Muon_pdgId",
-                               "Muon_pfRelIso04_all"])
-
-
-print(slim.show())

--- a/irishep/analysis/tests/test_nanoaod_columnar_analysis.py
+++ b/irishep/analysis/tests/test_nanoaod_columnar_analysis.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import unittest
+from unittest.mock import Mock, MagicMock
+
+from jinja2 import Environment, Template
+
+from irishep.analysis.nanoaod_columnar_analysis import NanoAODColumnarAnalysis
+from irishep.datasets.dataset import Dataset
+
+
+class TestNanoAODColumnarAnalysis(unittest.TestCase):
+    def test_render(self):
+        mock_dataset = Mock(Dataset)
+        mock_dataset.columns = ["dataset", "run", "luminosityBlock", "event",
+                                "nElectron,", "Electron_pt", "Electron_eta",
+                                "nMuon", "Muon_pt", "Muon_eta"]
+
+        mock_dataset.columns_for_physics_objects = Mock(
+            return_value=["nElectron", "Electron_pt", "Electron_eta", "nMuon",
+                          "Muon_pt", "Muon_eta"])
+        mock_dataset.count_column_for_physics_object = Mock(
+            side_effect=["nElectrons", "nMuons"])
+
+        analysis = NanoAODColumnarAnalysis()
+        analysis.env = MagicMock(Environment)
+        mock_template = MagicMock(Template)
+        mock_template.render = Mock(return_value="def udf(): pass")
+        analysis.env.get_template = Mock(return_value=mock_template)
+
+        analysis.generate_udf(mock_dataset, ["Electron", "Muon"],
+                              "Electron_pt",
+                              "my.analysis.class")
+
+        analysis.env.get_template.assert_called_with("mytemplate.py")
+
+        mock_template.render.assert_called_with(
+            analysis_class='my.analysis.class',
+            cols=['nElectron', 'Electron_pt', 'Electron_eta', 'nMuon',
+                  'Muon_pt', 'Muon_eta'],
+            physics_objects={
+                'Electron': ['nElectrons.array', 'pt=Electron_pt.array[0].base',
+                             'eta=Electron_eta.array[0].base'],
+                'Muon': ['nMuons.array', 'pt=Muon_pt.array[0].base',
+                         'eta=Muon_eta.array[0].base']},
+            return_expr='Electron_pt')

--- a/irishep/analysis/tests/test_user_analysis.py
+++ b/irishep/analysis/tests/test_user_analysis.py
@@ -1,0 +1,18 @@
+import unittest
+
+from irishep.analysis.user_analysis import UserAnalysis
+
+
+class MyTestCase(unittest.TestCase):
+    @staticmethod
+    def test_base_class():
+        class MySubclass(UserAnalysis):
+            @staticmethod
+            def calc(pyhsics_objects):
+                pass
+
+        MySubclass()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/irishep/analysis/user_analysis.py
+++ b/irishep/analysis/user_analysis.py
@@ -26,37 +26,16 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from irishep.config import Config
-from irishep.datasets.files_dataset_manager import FilesDatasetManager
-from irishep.app import App
-
-config = Config(
-    dataset_manager=FilesDatasetManager(database_file="demo_datasets.csv")
-)
-app = App(config=config)
-print(app.datasets.get_names())
-
-dataset = app.read_dataset("DY Jets")
-print(dataset.name, dataset.count())
-print(dataset.columns)
-print (dataset.columns_with_types)
-
-slim = dataset.select_columns(["nElectron",
-                               "Electron_pt",
-                               "Electron_eta",
-                               "Electron_phi",
-                               "Electron_mass",
-                               "Electron_cutBased",
-                               "Electron_pdgId",
-                               "Electron_pfRelIso03_all",
-                               "nMuon",
-                               "Muon_pt",
-                               "Muon_eta",
-                               "Muon_phi",
-                               "Muon_mass",
-                               "Muon_tightId",
-                               "Muon_pdgId",
-                               "Muon_pfRelIso04_all"])
+from abc import ABCMeta, abstractmethod
 
 
-print(slim.show())
+class UserAnalysis(metaclass=ABCMeta):
+    @staticmethod
+    @abstractmethod
+    def calc(pyhsics_objects):
+        """
+        The actual user analysis code that can run on the jagged arrays
+        :param pyhsics_objects: Dictionary of jagged arrays keyed on
+        physics object name
+        :return: None
+        """

--- a/irishep/datasets/tests/test_dataset.py
+++ b/irishep/datasets/tests/test_dataset.py
@@ -1,16 +1,24 @@
 import unittest
-from unittest.mock import Mock, patch
-
+from unittest.mock import Mock, patch, MagicMock
 import pyspark.sql
-
 from irishep.datasets.dataset import Dataset
 
 
 class TestDataset(unittest.TestCase):
     @staticmethod
     def _generate_mock_dataframe():
-        mock_dataframe = Mock(pyspark.sql.DataFrame)
+        mock_dataframe = MagicMock(pyspark.sql.DataFrame)
         mock_dataframe.columns = ['dataset', 'run']
+        mock_dataframe.dtypes = [
+            ('Electron_pt', 'string'),
+            ('event', 'string'), ('luminosityBlock', 'string'),
+            ("dataset", "string"), ('run', 'string')]
+
+        # Mock dataframe subscripting to get columns
+        mock_dataframe.__getitem__.side_effect = ['Electron_pt', 'dataset',
+                                                  'event', 'luminosityBlock',
+                                                  'run']
+
         return mock_dataframe
 
     def test_constuctor(self):
@@ -53,12 +61,32 @@ class TestDataset(unittest.TestCase):
         cols = a_dataset.columns_with_types
         self.assertEqual(cols, [('a', 'int'), ('b', 'string')])
 
+    def test_columns_for_physics_objects(self):
+        mock_dataframe = self._generate_mock_dataframe()
+        mock_dataframe.columns = ["dataset", "run", "luminosityBlock", "event",
+                                  "nElectrons", "Electron_pt", "Electron_eta",
+                                  "nMuons", "Muon_pt", "Muon_eta"]
+        a_dataset = Dataset("my dataset", mock_dataframe)
+        rslt = a_dataset.columns_for_physics_objects(["Electron", "Muon"])
+        self.assertEqual(rslt,
+                         ['nElectrons', 'Electron_pt', 'Electron_eta', 'nMuons',
+                          'Muon_pt', 'Muon_eta'])
+
+    def test_count_column_for_physics_object(self):
+        mock_dataframe = self._generate_mock_dataframe()
+        a_dataset = Dataset("my dataset", mock_dataframe)
+        self.assertEqual("nElectron",
+                         a_dataset.count_column_for_physics_object("Electron"))
+
+    # Given I included the technical fields in a select. When I perform the
+    # select then I should see a dataframe that holds my fields
     def test_select_provide_technical_fields(self):
         mock_dataframe = self._generate_mock_dataframe()
         mock_dataframe2 = self._generate_mock_dataframe()
         mock_dataframe.select = Mock(return_value=mock_dataframe2)
 
         a_dataset = Dataset("my dataset", mock_dataframe)
+
         a_dataset2 = a_dataset.select_columns(
             ["dataset", "run", "luminosityBlock", "event", "Electron_pt"])
 
@@ -72,9 +100,51 @@ class TestDataset(unittest.TestCase):
             ["dataset", "run", "luminosityBlock", "event", "Electron_pt"]),
             sorted(call_args))
 
+    # Given I included the technical fields in a select
+    # and I include a field that has a type that is not supported by arrow.
+    # When I perform the select then I should see a dataframe that holds my
+    # fields with the non-supported column cast appropriately
+    def test_select_non_arrow_type(self):
+        mock_dataframe = self._generate_mock_dataframe()
+        mock_dataframe2 = self._generate_mock_dataframe()
+        mock_dataframe2.dtypes = [
+            ('Muon_tightId', 'array<boolean>'),
+            ('event', 'string'), ('luminosityBlock', 'string'),
+            ("dataset", "string"), ('run', 'string')]
+        mock_dataframe.columns = ['Muon_tightId',
+                                  'event', 'luminosityBlock',
+                                  "dataset", 'run']
+
+        # Mock dataframe subscripting to get columns
+        muon_tight_id_mock = MagicMock()
+        mock_dataframe2.__getitem__.side_effect = [muon_tight_id_mock,
+                                                   'dataset',
+                                                   'event', 'luminosityBlock',
+                                                   'run']
+
+        mock_dataframe.select = Mock(return_value=mock_dataframe2)
+
+        a_dataset = Dataset("my dataset", mock_dataframe)
+
+        a_dataset2 = a_dataset.select_columns(
+            ["dataset", "run", "luminosityBlock", "event", "Muon_tightId"])
+
+        self.assertEqual(mock_dataframe2, a_dataset2.dataframe)
+        self.assertEqual("my dataset", a_dataset2.name)
+
+        muon_tight_id_mock.cast.assert_called_with("array<int >")
+
+    # Given I did not inlude the technical fields in a select. When I perform
+    # the select then I should see a dataframe that holds my fields plus the
+    # technical fields
     def test_select_without_technical_fields(self):
         mock_dataframe = self._generate_mock_dataframe()
         mock_dataframe2 = self._generate_mock_dataframe()
+        mock_dataframe2.dtypes = [
+            ('Electron_pt', 'string'),
+            ('event', 'string'), ('luminosityBlock', 'string'),
+            ("dataset", "string"), ('run', 'string')]
+
         mock_dataframe.select = Mock(return_value=mock_dataframe2)
 
         a_dataset = Dataset("my dataset", mock_dataframe)
@@ -86,9 +156,9 @@ class TestDataset(unittest.TestCase):
         # The actual order of the selected columns is hard to predict. Use
         # sorted column names to test
         call_args = mock_dataframe.select.call_args[0][0]
-        self.assertEqual(sorted(
-            ["dataset", "run", "luminosityBlock", "event", "Electron_pt"]),
-            sorted(call_args))
+        self.assertEqual(sorted(call_args),
+                         sorted(["dataset", "run", "luminosityBlock", "event",
+                                 "Electron_pt"]))
 
     def test_show(self):
         mock_dataframe = self._generate_mock_dataframe()

--- a/irishep/templates/mytemplate.py
+++ b/irishep/templates/mytemplate.py
@@ -1,0 +1,18 @@
+def udf({% for col in cols %}{{col}}{{ "," if not loop.last }}{% endfor %}):
+    import pandas as pd
+    import numpy as np
+    from fnal_column_analysis_tools.analysis_objects import JaggedCandidateArray
+    from pydoc import locate
+
+    my_class = locate('{{analysis_class}}')
+    print(my_class)
+    physics_objects = {}
+    {% for obj in physics_objects.keys() %}
+    physics_objects["{{obj}}"] = \
+        JaggedCandidateArray.candidatesfromcounts(
+            {% for zip_entry in physics_objects.get(obj) %}{{zip_entry}}{{ "," if not loop.last }}
+            {% endfor %})
+    {% endfor %}
+
+    my_class.calc(physics_objects)
+    return {{return_expr}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ pyspark==2.4.0
 coverage==4.5.2
 codecov==2.0.15
 flake8==3.7.7
+appdirs==1.4.3
+pyparsing==2.1.10
+Jinja2==2.10


### PR DESCRIPTION
# Problem
Fixes #7 
Users need to be able to run their code as a Pandas UDF in spark. For convenience they will want the columns mapped from Pandas Series objects into Jagged Arrays, organized by Physics Objects.

# Approach
Use a templating framework (ninja2) to create a wrapper python function that handles the mapping between Pandas Series and JaggedArrays. User specifies their custom code with a subclass of `UserAnalysis` class. The calc method for now just takes a dictionary of JaggedArrays. Future stories will add histogram accumulators and broadcast of non-event data.