### PR TITLE
Make Histograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,15 @@ on the events. To do this you will want to implement a subclass of
 method will accept a dictionary of JaggedArrays. The keys in this dictionary
 are Physics Object names.
 
+You will most likely want to create a dictionary of `Accumulator`s which 
+are objects that support accumulation of results (typicall histograms). These
+are available to the `calc` method and can be retrieved after the dataset 
+is analyzed.
+
 You invoke this UDF by creating an instance of `NanoAODColumnarAnalysis`. This
 class makes assumptions about the CMS NanoAOD file format. Then call
 `generate_udf` with your projected dataset, the list of physics_objects you
-need to operate on, your code to execute on the return, and a fully 
-qualified analysis class name.
+need to operate on, and your code to execute on the return.
 
 
 ## How to Test

--- a/demo/zpeak_app.py
+++ b/demo/zpeak_app.py
@@ -30,6 +30,7 @@ from pyspark.sql.functions import pandas_udf, PandasUDFType
 from pyspark.sql.types import DoubleType
 
 from analysis.nanoaod_columnar_analysis import NanoAODColumnarAnalysis
+from demo.zpeak.zpeak_analysis import ZpeakAnalysis
 from irishep.app import App
 from irishep.config import Config
 from irishep.datasets.files_dataset_manager import FilesDatasetManager
@@ -38,11 +39,8 @@ config = Config(
     dataset_manager=FilesDatasetManager(database_file="../demo_datasets.csv")
 )
 app = App(config=config)
-print(app.datasets.get_names())
 
 dataset = app.read_dataset("DY Jets")
-print(dataset.columns)
-print (dataset.columns_with_types)
 
 slim = dataset.select_columns(["nElectron",
                                "Electron_pt",
@@ -61,11 +59,16 @@ slim = dataset.select_columns(["nElectron",
                                "Muon_pdgId",
                                "Muon_pfRelIso04_all"])
 
-analysis = NanoAODColumnarAnalysis()
+my_analysis = ZpeakAnalysis(app)
+analysis = NanoAODColumnarAnalysis(my_analysis)
 
-f = analysis.generate_udf(slim, ["Electron", "Muon"], "pd.Series(np.ones(Electron_pt.size))", "demo.zpeak.zpeak_analysis.ZpeakAnalysis" )
+f = analysis.generate_udf(slim, ["Electron", "Muon"],
+                          "pd.Series(np.ones(Electron_pt.size))")
+
 zpeak_udf = pandas_udf(f, DoubleType(), PandasUDFType.SCALAR)
 
-analysis = slim.dataframe.select(zpeak_udf(*slim.columns_for_physics_objects(["Electron", "Muon"])))
+# The Describe operation forces the DAG to execute
+slim.dataframe.select(
+    zpeak_udf(*slim.udf_arguments(["Electron", "Muon"]))).describe()
 
-analysis.show()
+print(my_analysis.accumulators["zMass"].accumulator.value.values())

--- a/irishep/analysis/accumulator.py
+++ b/irishep/analysis/accumulator.py
@@ -25,22 +25,37 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from abc import ABCMeta, abstractmethod
+
+from pyspark.accumulators import AccumulatorParam
+from abc import ABCMeta
 
 
-class ColumnarAnalysis(metaclass=ABCMeta):
-    def __init__(self):
-        """
-        Base class for a columnar style analysis
-        """
+class Accumulator(AccumulatorParam, metaclass=ABCMeta):
+    def __init__(self, spark_context):
+        self.accumulator = spark_context.accumulator(None, self)
 
-    @abstractmethod
-    def generate_udf(self, dataset, physics_objects, return_expr):
+    def zero(self, value):
         """
-        Create a function that implements a spark Pandas UDF
-        :param dataset: Dataset object that this analysis will run over
-        :param physics_objects: List of physics object names
-        :param return_expr: A string representing what you want to return from
-        the UDF
-        :return: The generated function
+        Implements method from AccumulatorParam. Just used to initialize
+        the accumulator
+        :param value: initial value for the accumulator
+        :return: same
         """
+        return value
+
+    def addInPlace(self, val1, val2):
+        """
+        Implements addInPlace for accumulator. Has special case for the first
+        time when the existing value may be None. In that case just set the
+        accumulator to the passed in new value. Otherwise add the passed in
+        value to the existing histogram
+        :param val1:
+        :param val2:
+        :return:
+        """
+        if val1:
+            val1 += val2
+        else:
+            val1 = val2
+
+        return val1

--- a/irishep/analysis/fnal_hist_accumulator.py
+++ b/irishep/analysis/fnal_hist_accumulator.py
@@ -25,22 +25,15 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from abc import ABCMeta, abstractmethod
+
+from irishep.analysis.accumulator import Accumulator
 
 
-class ColumnarAnalysis(metaclass=ABCMeta):
-    def __init__(self):
-        """
-        Base class for a columnar style analysis
-        """
-
-    @abstractmethod
-    def generate_udf(self, dataset, physics_objects, return_expr):
-        """
-        Create a function that implements a spark Pandas UDF
-        :param dataset: Dataset object that this analysis will run over
-        :param physics_objects: List of physics object names
-        :param return_expr: A string representing what you want to return from
-        the UDF
-        :return: The generated function
-        """
+class FnalHistAccumulator(Accumulator):
+    """
+    Acumulator based on the Fermilab Columnar Analyasis Histogram
+    """
+    def __init__(self, dataset_axis, channel_cat_axis, spark_context):
+        super().__init__(spark_context)
+        self.dataset_axis = dataset_axis
+        self.channel_cat_axis = channel_cat_axis

--- a/irishep/analysis/tests/test_fnal_hist_accumulator.py
+++ b/irishep/analysis/tests/test_fnal_hist_accumulator.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import Mock
+
+from pyspark import SparkContext
+
+import fnal_column_analysis_tools.hist as hist
+from irishep.analysis.fnal_hist_accumulator import FnalHistAccumulator
+
+
+class TestFNALHistAccumulator(unittest.TestCase):
+    @staticmethod
+    def _create_fnal_accumulator():
+        ds_axis = Mock(hist.Cat)
+        cat_axis = Mock(hist.Cat)
+        mock_spark = Mock(SparkContext)
+        mock_accumulator = Mock()
+        mock_spark.accumulator = Mock(return_value=mock_accumulator)
+        return FnalHistAccumulator(ds_axis, cat_axis, mock_spark)
+
+    def test_init(self):
+        ds_axis = Mock(hist.Cat)
+        cat_axis = Mock(hist.Cat)
+        mock_spark = Mock(SparkContext)
+        mock_accumulator = Mock()
+        mock_spark.accumulator = Mock(return_value=mock_accumulator)
+        accum = FnalHistAccumulator(ds_axis, cat_axis, mock_spark)
+
+        self.assertEqual(accum.dataset_axis, ds_axis)
+        self.assertEqual(accum.channel_cat_axis, cat_axis)
+        self.assertEqual(accum.accumulator, mock_accumulator)
+
+        mock_spark.accumulator.assert_called_with(None, accum)
+
+    def test_zero(self):
+        accum = self._create_fnal_accumulator()
+        result = accum.zero(1)
+        self.assertEqual(result, 1)
+
+    def test_add_in_place_first_time(self):
+        accum = self._create_fnal_accumulator()
+        result = accum.addInPlace(None, 1)
+        self.assertEqual(result, 1)
+
+    def test_add_in_place_second_time(self):
+        accum = self._create_fnal_accumulator()
+        result = accum.addInPlace(2, 1)
+        self.assertEqual(result, 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/irishep/analysis/tests/test_nanoaod_columnar_analysis.py
+++ b/irishep/analysis/tests/test_nanoaod_columnar_analysis.py
@@ -30,6 +30,7 @@ from unittest.mock import Mock, MagicMock
 
 from jinja2 import Environment, Template
 
+from irishep.analysis.user_analysis import UserAnalysis
 from irishep.analysis.nanoaod_columnar_analysis import NanoAODColumnarAnalysis
 from irishep.datasets.dataset import Dataset
 
@@ -46,22 +47,25 @@ class TestNanoAODColumnarAnalysis(unittest.TestCase):
                           "Muon_pt", "Muon_eta"])
         mock_dataset.count_column_for_physics_object = Mock(
             side_effect=["nElectrons", "nMuons"])
+        mock_dataset.udf_arguments = Mock(
+            return_value=['dataset', 'nElectron', 'Electron_pt', 'Electron_eta',
+                          'nMuon', 'Muon_pt', 'Muon_eta'])
 
-        analysis = NanoAODColumnarAnalysis()
+        mock_user_analysis = Mock(UserAnalysis)
+        analysis = NanoAODColumnarAnalysis(mock_user_analysis)
         analysis.env = MagicMock(Environment)
         mock_template = MagicMock(Template)
         mock_template.render = Mock(return_value="def udf(): pass")
         analysis.env.get_template = Mock(return_value=mock_template)
 
         analysis.generate_udf(mock_dataset, ["Electron", "Muon"],
-                              "Electron_pt",
-                              "my.analysis.class")
+                              "Electron_pt")
 
         analysis.env.get_template.assert_called_with("mytemplate.py")
 
         mock_template.render.assert_called_with(
-            analysis_class='my.analysis.class',
-            cols=['nElectron', 'Electron_pt', 'Electron_eta', 'nMuon',
+            cols=['dataset', 'nElectron', 'Electron_pt', 'Electron_eta',
+                  'nMuon',
                   'Muon_pt', 'Muon_eta'],
             physics_objects={
                 'Electron': ['nElectrons.array', 'pt=Electron_pt.array[0].base',

--- a/irishep/datasets/dataset.py
+++ b/irishep/datasets/dataset.py
@@ -137,6 +137,16 @@ class Dataset:
         return Dataset(name=self.name,
                        dataframe=self.dataframe.select(list(columns3)))
 
+    def udf_arguments(self, physics_objects):
+        """
+        Construct the set of argumnents to UDFs on this dataset based on the
+        requested Physics Objects.
+        For now we also include the dataset name column for bookkeeping
+        :param physics_objects: List of physics object names
+        :return: List of colums for passing in as arguments to UDF
+        """
+        return ["dataset"]+self.columns_for_physics_objects(physics_objects)
+
     def show(self):
         """
         Print out a friendly representation of the dataframe

--- a/irishep/datasets/tests/test_dataset.py
+++ b/irishep/datasets/tests/test_dataset.py
@@ -160,6 +160,16 @@ class TestDataset(unittest.TestCase):
                          sorted(["dataset", "run", "luminosityBlock", "event",
                                  "Electron_pt"]))
 
+    def test_udf_arguments(self):
+        mock_dataframe = self._generate_mock_dataframe()
+        mock_dataframe.columns = ["dataset", "run", "luminosityBlock", "event",
+                                  "nElectrons", "Electron_pt", "Electron_eta",
+                                  "nMuons", "Muon_pt", "Muon_eta"]
+        a_dataset = Dataset("my dataset", mock_dataframe)
+        result = a_dataset.udf_arguments(["Electron"])
+        self.assertEqual(
+            ['dataset', 'nElectrons', 'Electron_pt', 'Electron_eta'], result)
+
     def test_show(self):
         mock_dataframe = self._generate_mock_dataframe()
         mock_dataframe.show = Mock()

--- a/irishep/templates/mytemplate.py
+++ b/irishep/templates/mytemplate.py
@@ -2,10 +2,8 @@ def udf({% for col in cols %}{{col}}{{ "," if not loop.last }}{% endfor %}):
     import pandas as pd
     import numpy as np
     from fnal_column_analysis_tools.analysis_objects import JaggedCandidateArray
-    from pydoc import locate
+    global my_analysis
 
-    my_class = locate('{{analysis_class}}')
-    print(my_class)
     physics_objects = {}
     {% for obj in physics_objects.keys() %}
     physics_objects["{{obj}}"] = \
@@ -14,5 +12,5 @@ def udf({% for col in cols %}{{col}}{{ "," if not loop.last }}{% endfor %}):
             {% endfor %})
     {% endfor %}
 
-    my_class.calc(physics_objects)
+    my_analysis.calc(physics_objects, dataset[0])
     return {{return_expr}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flake8==3.7.7
 appdirs==1.4.3
 pyparsing==2.1.10
 Jinja2==2.10
+fnal-column-analysis-tools>=0.2.5


### PR DESCRIPTION
# Problem
Fixes #9 
User defined functions need a way to output a summary of the data in the events. This typically takes the form of histograms.

# Approach
Extended the `NanoAODColumnarAnalysis` to support an additional dictionary of Spark Accumulators. These are available to the UDF so that it's easy to find them and accumulate results.

# How to test
The `demo/zpeak_app` application along with `demo/zpeak/zpeak_analysis` shows how this works in  practice. Run the example.