### PR TITLE
Add nonevent data to model

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ are objects that support accumulation of results (typicall histograms). These
 are available to the `calc` method and can be retrieved after the dataset 
 is analyzed.
 
+If you have nonevent data that you want to load in from the driver and make
+available inside the udf, you can create a `NonEventData` instance and add 
+it to the user analysis instance.
+
 You invoke this UDF by creating an instance of `NanoAODColumnarAnalysis`. This
 class makes assumptions about the CMS NanoAOD file format. Then call
 `generate_udf` with your projected dataset, the list of physics_objects you

--- a/irishep/analysis/nonevent_data.py
+++ b/irishep/analysis/nonevent_data.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+class NonEventData:
+    def __init__(self, app, value):
+        self.broadcast_var = app.spark.sparkContext.broadcast(value)
+
+    @property
+    def value(self):
+        return self.broadcast_var.value

--- a/irishep/analysis/tests/test_nonevent_data.py
+++ b/irishep/analysis/tests/test_nonevent_data.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import Mock
+
+from pyspark import SparkContext
+
+from irishep.analysis.nonevent_data import NonEventData
+
+
+class TestNoneventData(unittest.TestCase):
+    @staticmethod
+    def _create_mock_app():
+        mock_app = Mock()
+        mock_app.spark = Mock()
+        mock_app.spark.sparkContext = Mock(SparkContext)
+        return mock_app
+
+    def test_init(self):
+        app = self._create_mock_app()
+        mock_broadcast = Mock()
+        app.spark.sparkContext.broadcast = Mock(return_value=mock_broadcast)
+
+        data = "hi"
+        nonevent_data = NonEventData(app, data)
+        self.assertTrue(nonevent_data)
+        app.spark.sparkContext.broadcast.assert_called_with(data)
+
+    def test_value(self):
+        app = self._create_mock_app()
+        mock_broadcast = Mock()
+        app.spark.sparkContext.broadcast = Mock(return_value=mock_broadcast)
+        mock_broadcast.value = "hi"
+
+        nonevent_data = NonEventData(app, {})
+        self.assertEqual("hi", nonevent_data.value)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Problem
Fixes #8 
Analyses often need additional data such as weights. We need a way for an analyzer to load these values from their workstation and make them available in the worker nodes.

# Approach
The Spark Broadcast variable was designed specifically for this sort of case. Created a class to wrap this functionality and updated the zpeak_app script to show it in use.

