### PR TITLE
Partition Datasets

### DIFF
--- a/irishep/app.py
+++ b/irishep/app.py
@@ -34,6 +34,7 @@ from irishep.datasets.dataset import Dataset
 
 class App:
     def __init__(self, config):
+        self.config = config
         self.spark = SparkSession.builder \
             .master(config.master) \
             .appName(config.app_name) \
@@ -75,4 +76,7 @@ class App:
             # So just append each file's datafrane into one big one
             result_df = file_df if not result_df else result_df.union(file_df)
 
-        return Dataset(dataset_name, result_df)
+        dataset = Dataset(dataset_name, result_df)
+        dataset.repartition(self.config.num_partitions)
+
+        return dataset

--- a/irishep/config.py
+++ b/irishep/config.py
@@ -40,12 +40,16 @@ class Config:
         app_name: String, optional
             String name that will be passed to spark to reference this
             application
+        num_partitions: Int, optional
+            Number of partitions to spread datasets over.
     """
     def __init__(self,
                  dataset_manager=None,
                  master="local",
-                 app_name="spark-hep"):
+                 app_name="spark-hep",
+                 num_partitions=10):
 
         self.dataset_manager = dataset_manager
         self.master = master
         self.app_name = app_name
+        self.num_partitions = num_partitions

--- a/irishep/datasets/dataset.py
+++ b/irishep/datasets/dataset.py
@@ -153,3 +153,11 @@ class Dataset:
         :return: None
         """
         self.dataframe.show()
+
+    def repartition(self, num_partitions):
+        """
+        Distribute the dataframe across the given number of partitions
+        :param num_partitions: Number of partitions
+        :return: None
+        """
+        self.dataframe = self.dataframe.repartition(num_partitions)

--- a/irishep/datasets/tests/test_dataset.py
+++ b/irishep/datasets/tests/test_dataset.py
@@ -178,6 +178,14 @@ class TestDataset(unittest.TestCase):
 
         mock_dataframe.show.assert_called_once()
 
+    def test_repartition(self):
+        mock_dataframe = self._generate_mock_dataframe()
+        mock_dataframe.repartition = Mock()
+        a_dataset = Dataset("my dataset", mock_dataframe)
+
+        a_dataset.repartition(42)
+        mock_dataframe.repartition.assert_called_with(42)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Problem
Fixes #17 
Spark's performance depends a great deal on how a data frame is partitioned. The default partitioning is not very good. Need a way to automatically partition datasets and allow for manual override.

# Approach
Added a new config setting, `num_partititions` which will be the default number of partitions. When datasets are loaded, this will be applied. Added a new method on `dataset` to allow user code to 
override the default.
