### PR TITLE
Uproot Subclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 .mypy_cache/
 
 .idea/
+metastore_db/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,19 @@ physics data.
 
 ## Application
 The main entrypoint for the query service is through an instance of the `App` 
-class.  It is constructed from a `Config` object specification.
+class.  It is constructed from a `Config` object specification. Depending on the
+configuration, it can run on a spark cluster, or locally as an Uproot 
+analysis.
+
+## Configuration
+The config class accepts to configured instances:
+- The dataset manager
+- The executor
+
+## Executors
+The actual analysis is run by the executor. We have two classes:
+1. SparkExecutor to run the analysis on a Spark Cluster
+2. UprootExectutor runs the code locally using Uproot
 
 ## Dataset Management
 We don't want analyzers to have to think about individual ROOT files. 
@@ -16,6 +28,11 @@ more sophisticated implementations, our first draft for testing and development
 relies on a local csv file with dataset names and paths to the files. A 
 dataset can be composed of multiple files. This is represented as rows sharing 
 the same dataset name.
+
+This file can be consumed by a `FilesDatasetManager` which uses the underlying
+spark infrastructure for searching for datasets, or the even simplier 
+`InMemoryFilesDatasetManager` which uses a dictionary in memory to hold a small
+number of datasets. This is useful for the uproot run environment.
 
 An instance of the dataset manager is created as part of the `config` object 
 and passed into the application initializer.
@@ -45,8 +62,7 @@ For now, we are assuming that we are working with a CMS NanoAOD file. This
 will need more flexibility as we gain experience with new file formats.
 
 ### Dataset Operations
-There are some useful methods on dataset (which are mostly just passed
-through to Spark)
+There are some useful methods on dataset 
 
 `count` - Returns the number of events in the dataset
 
@@ -95,3 +111,7 @@ report with
 coverage run -m unittest
 coverage report
 ```
+
+## Run a sample App
+Run `demo/zpeak_app.py`. It is configured to use an Uproot executor and load
+a local nanoAOD file. There is a commented out config to switch to spark.

--- a/demo/zpeak/zpeak_analysis.py
+++ b/demo/zpeak/zpeak_analysis.py
@@ -36,16 +36,18 @@ import fnal_column_analysis_tools.hist as hist
 class ZpeakAnalysis(UserAnalysis):
     def __init__(self, app, nonevent_data):
         self.accumulators = {
-            "zMass": FnalHistAccumulator(dataset_axis=hist.Cat("dataset", "DAS name"),
-                                 channel_cat_axis=hist.Cat("channel",
-                                                           "dilepton flavor"),
-                                 spark_context=app.executor.spark.sparkContext
-                                 )}
+            "zMass": FnalHistAccumulator(
+                dataset_axis=hist.Cat("dataset", "DAS name"),
+                channel_cat_axis=hist.Cat("channel",
+                                          "dilepton flavor"),
+                app=app
+                )}
 
         self.nonevent_data = NonEventData(app, nonevent_data)
 
     def calc(self, physics_objects, dataset_name):
         electrons = physics_objects["Electron"]
+
         ele = electrons[(electrons.pt > 20) &
                         (np.abs(electrons.eta) < 2.5) &
                         (electrons.cutBased >= 4)]
@@ -99,3 +101,4 @@ class ZpeakAnalysis(UserAnalysis):
                        weight=weight.flatten())
 
             zMassHist.accumulator.add(zMass)
+        return np.zeros(electrons.pt.size)

--- a/demo/zpeak/zpeak_analysis.py
+++ b/demo/zpeak/zpeak_analysis.py
@@ -39,7 +39,7 @@ class ZpeakAnalysis(UserAnalysis):
             "zMass": FnalHistAccumulator(dataset_axis=hist.Cat("dataset", "DAS name"),
                                  channel_cat_axis=hist.Cat("channel",
                                                            "dilepton flavor"),
-                                 spark_context=app.spark.sparkContext
+                                 spark_context=app.executor.spark.sparkContext
                                  )}
 
         self.nonevent_data = NonEventData(app, nonevent_data)

--- a/demo/zpeak_app.py
+++ b/demo/zpeak_app.py
@@ -25,22 +25,30 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import sys
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import PandasUDFType, pandas_udf
 from pyspark.sql.types import DoubleType
 
-from irishep.analysis.nanoaod_columnar_analysis import NanoAODColumnarAnalysis
-from irishep.analysis.nonevent_data import NonEventData
-from demo.zpeak.zpeak_analysis import ZpeakAnalysis
+from analysis.nanoaod_columnar_analysis import NanoAODColumnarAnalysis
+from fnal_column_analysis_tools import lookup_tools
+
+from irishep.executors.uproot_executor import UprootExecutor
+from irishep.executors.spark_executor import SparkExecutor
 from irishep.app import App
 from irishep.config import Config
-from irishep.datasets.files_dataset_manager import FilesDatasetManager
-import fnal_column_analysis_tools.lookup_tools as lookup_tools
+from irishep.datasets.inmemory_files_dataset_manager import \
+    InMemoryFilesDatasetManager
+from zpeak_analysis import ZpeakAnalysis
 
 config = Config(
-    dataset_manager=FilesDatasetManager(database_file="demo_datasets.csv")
+    executor = SparkExecutor("local", "ZPeak", 20),
+    dataset_manager=InMemoryFilesDatasetManager(database_file="demo_datasets.csv")
 )
 app = App(config=config)
+print(app.datasets.get_names())
+print(app.datasets.get_file_list("ZJetsToNuNu_HT-600To800_13TeV-madgraph"))
+
 
 # Create a broadcast variable for the non-event data
 weightsext = lookup_tools.extractor()

--- a/demo/zpeak_uproot.py
+++ b/demo/zpeak_uproot.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import sys
+import uproot
+import os
+import numpy as np
+from fnal_column_analysis_tools import hist
+
+from fnal_column_analysis_tools.analysis_objects.JaggedCandidateArray import \
+    JaggedCandidateArray
+
+BINS = 10
+HIST_RANGE = (0.05, 0.2)
+
+dataset_axis=hist.Cat("dataset", "DAS name")
+channel_cat_axis=hist.Cat("channel", "dilepton flavor")
+
+file = uproot.open(os.path.join("..","..","data","DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.root"))
+events = file["Events"]
+
+arrays = events.arrays(["nElectron",
+                   "Electron_pt",
+                   "Electron_eta",
+                   "Electron_phi",
+                   "Electron_mass",
+                   "Electron_cutBased",
+                   "Electron_pdgId",
+                   "Electron_pfRelIso03_all"])
+
+physics_objects = {}
+
+physics_objects["Electron"] = \
+    JaggedCandidateArray.candidatesfromcounts(arrays[b'nElectron'],
+                                              pt=arrays[b"Electron_pt"].content,
+                                              eta=arrays[b"Electron_eta"].content,
+                                              phi=arrays[b"Electron_phi"].content,
+                                              mass=arrays[b"Electron_mass"].content,
+                                              cutBased=arrays[
+                                                  b"Electron_cutBased"].content,
+                                              pdgId=arrays[b"Electron_pdgId"].content,
+                                              pfRelIso03_all=arrays[
+                                                  b"Electron_pfRelIso03_all"].content)
+
+electrons = physics_objects["Electron"]
+
+print(electrons.pt.size)
+print("---->",electrons[(electrons.pt > 20)])
+
+sys.exit(0)
+
+e_counts = ele_arrays.pop(b'nElectron')
+ele_arrays = {'_'.join(key.decode().split('_')[1:]): array.content for key , array in ele_arrays.items()}
+
+electrons = JaggedCandidateArray.candidatesfromcounts(e_counts, **ele_arrays)
+
+muon_arrays = events.arrays([
+    "nMuon",
+    "Muon_pt",
+    "Muon_eta",
+    "Muon_phi",
+    "Muon_mass",
+    "Muon_tightId",
+    "Muon_pdgId",
+    "Muon_pfRelIso04_all"])
+
+m_counts = muon_arrays.pop(b'nMuon')
+muon_arrays = {'_'.join(key.decode().split('_')[1:]): array.content for key , array in muon_arrays.items()}
+muons = JaggedCandidateArray.candidatesfromcounts(m_counts, **muon_arrays)
+
+ele = electrons[(electrons.pt > 20) &
+                (np.abs(electrons.eta) < 2.5) &
+                (electrons.cutBased >= 4)]
+
+mu = muons[(muons.pt > 20) &
+           (np.abs(muons.eta) < 2.4) &
+           (muons.tightId > 0)]
+
+ee = ele.distincts()
+mm = mu.distincts()
+em = ele.cross(mu)
+
+dileptons = {}
+
+dileptons['ee'] = ee[
+    (ee.i0.pdgId * ee.i1.pdgId == -11 * 11) & (ee.i0.pt > 25)]
+dileptons['mm'] = mm[(mm.i0.pdgId * mm.i1.pdgId == -13 * 13)]
+dileptons['em'] = em[(em.i0.pdgId * em.i1.pdgId == -11 * 13)]
+
+channels = {}
+channels['ee'] = (ee.counts == 1) & (mu.counts == 0)
+channels['mm'] = (mm.counts == 1) & (ele.counts == 0)
+channels['em'] = (em.counts == 1) & (ele.counts == 1) & (
+    mu.counts == 1)
+
+dupe = np.zeros(events.array("Muon_pt").size, dtype=bool)
+tot = 0
+
+isRealData = True
+for channel, cut in channels.items():
+    zcands = dileptons[channel][cut]
+    # dupe |= cut
+    tot += cut.sum()
+    weight = np.array(1.)
+    zMass = hist.Hist("Events", dataset_axis,
+                      channel_cat_axis,
+                      hist.Bin("mass", "$m_{\ell\ell}$ [GeV]",
+                               120, 0, 120),
+                      )
+
+    zMass.fill(dataset="uproot", channel=channel,
+               mass=zcands.mass.flatten(),
+               weight=weight.flatten())
+
+    print(zMass.values())
+

--- a/irishep/analysis/accumulator.py
+++ b/irishep/analysis/accumulator.py
@@ -31,8 +31,8 @@ from abc import ABCMeta
 
 
 class Accumulator(AccumulatorParam, metaclass=ABCMeta):
-    def __init__(self, spark_context):
-        self.accumulator = spark_context.accumulator(None, self)
+    def __init__(self, app):
+        self.accumulator = app.executor.register_accumulator(None, self)
 
     def zero(self, value):
         """

--- a/irishep/analysis/columnar_analysis.py
+++ b/irishep/analysis/columnar_analysis.py
@@ -29,10 +29,11 @@ from abc import ABCMeta, abstractmethod
 
 
 class ColumnarAnalysis(metaclass=ABCMeta):
-    def __init__(self):
+    def __init__(self, app):
         """
         Base class for a columnar style analysis
         """
+        self.app = app
 
     @abstractmethod
     def generate_udf(self, dataset, physics_objects, return_expr):
@@ -42,5 +43,6 @@ class ColumnarAnalysis(metaclass=ABCMeta):
         :param physics_objects: List of physics object names
         :param return_expr: A string representing what you want to return from
         the UDF
-        :return: The generated function
+        :return: An instance of UserDefinedFunction containing the generated
+        function
         """

--- a/irishep/analysis/fnal_hist_accumulator.py
+++ b/irishep/analysis/fnal_hist_accumulator.py
@@ -33,7 +33,7 @@ class FnalHistAccumulator(Accumulator):
     """
     Acumulator based on the Fermilab Columnar Analyasis Histogram
     """
-    def __init__(self, dataset_axis, channel_cat_axis, spark_context):
-        super().__init__(spark_context)
+    def __init__(self, dataset_axis, channel_cat_axis, app):
+        super().__init__(app)
         self.dataset_axis = dataset_axis
         self.channel_cat_axis = channel_cat_axis

--- a/irishep/analysis/nanoaod_columnar_analysis.py
+++ b/irishep/analysis/nanoaod_columnar_analysis.py
@@ -25,20 +25,24 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from irishep.analysis.columnar_analysis import ColumnarAnalysis
-from jinja2 import Environment, PackageLoader, select_autoescape
 import re
+
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+from irishep.analysis.columnar_analysis import ColumnarAnalysis
+from irishep.analysis.user_defined_function import UserDefinedFunction
 
 
 class NanoAODColumnarAnalysis(ColumnarAnalysis):
     obj_property_re = re.compile("^[A-Za-z0-9]+_(.*)")
+    analysis_type = "nanoAOD"
 
-    def __init__(self, user_analysis):
+    def __init__(self, app, user_analysis):
         """
         :param user_analysis: Subclass of UserAnalysis that contains the user
         code to execute
         """
-        super().__init__()
+        super().__init__(app)
         self.env = Environment(
             loader=PackageLoader('irishep', 'templates'),
             autoescape=select_autoescape(['py'])
@@ -54,8 +58,17 @@ class NanoAODColumnarAnalysis(ColumnarAnalysis):
         that column
         """
         match = re.match(self.obj_property_re, col_name)
-        item = '{}={}.array[0].base'.format(match.group(1), col_name)
-        return item
+        return {"physics_obj_property": match.group(1), "col": col_name}
+        # item = '{}={}.array[0].base'.format(match.group(1), col_name)
+        # return item
+
+    @property
+    def _template_name(self):
+        if self.analysis_type in self.app.executor.templates:
+            return self.app.executor.templates[self.analysis_type]
+        else:
+            raise ValueError(
+                "No %s template found in executor" % self.analysis_type)
 
     def generate_udf(self, dataset, physics_objects, return_expr):
         """
@@ -70,17 +83,17 @@ class NanoAODColumnarAnalysis(ColumnarAnalysis):
         # Create a directory of JaggedArray zip entries. One for each physics
         # object. Each entry in the dictionary is a list of zip entries. The
         # zip entries include one for the count series (i.e. nElectron)
-        objects = {o:
-                   ["{}.array".format(
-                       dataset.count_column_for_physics_object(o))] +
-                   [
-                       self._zip_entry(c) for c in dataset.columns if
-                       c.startswith(o + "_")
-                   ] for o in physics_objects
+        objects = {o: [self._zip_entry(c)
+                       for c in dataset.columns if c.startswith(o + "_")]
+                   for o in physics_objects
                    }
 
-        template = self.env.get_template('mytemplate.py')
+        counts = {o: dataset.count_column_for_physics_object(o) for o in
+                  physics_objects}
+
+        template = self.env.get_template(self._template_name)
         udf_str = template.render(physics_objects=objects,
+                                  counts=counts,
                                   cols=dataset.udf_arguments(physics_objects),
                                   return_expr=return_expr)
 
@@ -93,4 +106,5 @@ class NanoAODColumnarAnalysis(ColumnarAnalysis):
         globals()['my_analysis'] = self.user_analysis
 
         # Assume that the template renders to a def udf(....)
-        return locals()['udf']
+        result = UserDefinedFunction(physics_objects, locals()['udf'])
+        return result

--- a/irishep/analysis/nonevent_data.py
+++ b/irishep/analysis/nonevent_data.py
@@ -29,7 +29,7 @@
 
 class NonEventData:
     def __init__(self, app, value):
-        self.broadcast_var = app.spark.sparkContext.broadcast(value)
+        self.broadcast_var = app.executor.register_broadcast_var(value)
 
     @property
     def value(self):

--- a/irishep/analysis/tests/test_fnal_hist_accumulator.py
+++ b/irishep/analysis/tests/test_fnal_hist_accumulator.py
@@ -1,10 +1,10 @@
 import unittest
 from unittest.mock import Mock
 
-from pyspark import SparkContext
-
 import fnal_column_analysis_tools.hist as hist
 from irishep.analysis.fnal_hist_accumulator import FnalHistAccumulator
+from irishep.app import App
+from irishep.executors.executor import Executor
 
 
 class TestFNALHistAccumulator(unittest.TestCase):
@@ -12,24 +12,25 @@ class TestFNALHistAccumulator(unittest.TestCase):
     def _create_fnal_accumulator():
         ds_axis = Mock(hist.Cat)
         cat_axis = Mock(hist.Cat)
-        mock_spark = Mock(SparkContext)
-        mock_accumulator = Mock()
-        mock_spark.accumulator = Mock(return_value=mock_accumulator)
-        return FnalHistAccumulator(ds_axis, cat_axis, mock_spark)
+        mock_app = Mock(App)
+        mock_app.executor = Mock(Executor)
+        mock_app.executor.register_accumulator = Mock()
+        return FnalHistAccumulator(ds_axis, cat_axis, mock_app)
 
     def test_init(self):
         ds_axis = Mock(hist.Cat)
         cat_axis = Mock(hist.Cat)
-        mock_spark = Mock(SparkContext)
-        mock_accumulator = Mock()
-        mock_spark.accumulator = Mock(return_value=mock_accumulator)
-        accum = FnalHistAccumulator(ds_axis, cat_axis, mock_spark)
+        mock_app = Mock(App)
+        mock_app.executor = Mock(Executor)
+        mock_app.executor.register_accumulator = Mock(
+            return_value="MyAccumulator")
+        accum = FnalHistAccumulator(ds_axis, cat_axis, mock_app)
 
         self.assertEqual(accum.dataset_axis, ds_axis)
         self.assertEqual(accum.channel_cat_axis, cat_axis)
-        self.assertEqual(accum.accumulator, mock_accumulator)
+        self.assertEqual(accum.accumulator, "MyAccumulator")
 
-        mock_spark.accumulator.assert_called_with(None, accum)
+        mock_app.executor.register_accumulator.assert_called_with(None, accum)
 
     def test_zero(self):
         accum = self._create_fnal_accumulator()

--- a/irishep/analysis/tests/test_nonevent_data.py
+++ b/irishep/analysis/tests/test_nonevent_data.py
@@ -1,8 +1,6 @@
 import unittest
 from unittest.mock import Mock
 
-from pyspark import SparkContext
-
 from irishep.analysis.nonevent_data import NonEventData
 
 
@@ -10,24 +8,25 @@ class TestNoneventData(unittest.TestCase):
     @staticmethod
     def _create_mock_app():
         mock_app = Mock()
-        mock_app.spark = Mock()
-        mock_app.spark.sparkContext = Mock(SparkContext)
+        mock_app.executor = Mock()
+        mock_app.executor.register_broadcast_var = Mock()
         return mock_app
 
     def test_init(self):
-        app = self._create_mock_app()
+        mock_app = self._create_mock_app()
         mock_broadcast = Mock()
-        app.spark.sparkContext.broadcast = Mock(return_value=mock_broadcast)
+        mock_app.executor.register_broadcast_var = Mock(
+            return_value=mock_broadcast)
 
         data = "hi"
-        nonevent_data = NonEventData(app, data)
+        nonevent_data = NonEventData(mock_app, data)
         self.assertTrue(nonevent_data)
-        app.spark.sparkContext.broadcast.assert_called_with(data)
+        mock_app.executor.register_broadcast_var.assert_called_with(data)
 
     def test_value(self):
         app = self._create_mock_app()
         mock_broadcast = Mock()
-        app.spark.sparkContext.broadcast = Mock(return_value=mock_broadcast)
+        app.executor.register_broadcast_var = Mock(return_value=mock_broadcast)
         mock_broadcast.value = "hi"
 
         nonevent_data = NonEventData(app, {})

--- a/irishep/analysis/user_defined_function.py
+++ b/irishep/analysis/user_defined_function.py
@@ -25,45 +25,9 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from pyspark.sql import SparkSession
-
-from irishep.datasets.spark_dataset import SparkDataset
-from irishep.executors.executor import Executor
 
 
-class SparkExecutor(Executor):
-    templates = {
-        "nanoAOD": "mytemplate.py"
-    }
-
-    def __init__(self, master, app_name, num_partitions):
-        super().__init__(app_name)
-        self.spark = SparkSession.builder \
-            .master(master) \
-            .appName(app_name) \
-            .config("spark.jars.packages",
-                    "org.diana-hep:spark-root_2.11:0.1.15") \
-            .getOrCreate()
-        self.num_partitions = num_partitions
-
-    def read_files(self, dataset_name, files):
-        result_df = None
-        # Sparkroot can't handle list of files
-        for file in files:
-            file_df = self.spark.read.format("org.dianahep.sparkroot") \
-                .option("tree", "Events") \
-                .load(file)
-
-            # So just append each file's datafrane into one big one
-            result_df = file_df if not result_df else result_df.union(file_df)
-
-        dataset = SparkDataset(dataset_name, result_df)
-        dataset.repartition(self.num_partitions)
-
-        return dataset
-
-    def register_accumulator(self, initial_value, accumulator):
-        return self.spark.sparkContext.accumulator(initial_value, accumulator)
-
-    def register_broadcast_var(self, var):
-        return self.spark.sparkContext.broadcast(var)
+class UserDefinedFunction:
+    def __init__(self, physics_objects, a_func):
+        self.physics_objects = physics_objects
+        self.function = a_func

--- a/irishep/config.py
+++ b/irishep/config.py
@@ -35,21 +35,14 @@ class Config:
     ----------
         dataset_manager: DatasetManager, optional
             Instance of dataset manager
-        master: String, optional
-            Reference to spark master. Defaults to local
-        app_name: String, optional
-            String name that will be passed to spark to reference this
-            application
         num_partitions: Int, optional
             Number of partitions to spread datasets over.
     """
+
     def __init__(self,
                  dataset_manager=None,
-                 master="local",
-                 app_name="spark-hep",
+                 executor=None,
                  num_partitions=10):
-
         self.dataset_manager = dataset_manager
-        self.master = master
-        self.app_name = app_name
+        self.executor = executor
         self.num_partitions = num_partitions

--- a/irishep/config.py
+++ b/irishep/config.py
@@ -35,6 +35,7 @@ class Config:
     ----------
         dataset_manager: DatasetManager, optional
             Instance of dataset manager
+        executor: Instance of executor where the analysis will be run
         num_partitions: Int, optional
             Number of partitions to spread datasets over.
     """

--- a/irishep/datasets/awkward_dataset.py
+++ b/irishep/datasets/awkward_dataset.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from irishep.datasets.dataset import Dataset
+import awkward as awk
+import numpy as np
+
+
+class AwkwardDataset(Dataset):
+    def __init__(self, name, array_dict):
+        super().__init__(name)
+
+        self.arrays = {key.decode("utf-8"): value for key, value in
+                       array_dict.items()}
+
+        # Add in the technical dataset column if not already there
+        if 'dataset' not in self.arrays.keys():
+            dataset_dtype = '<U%d' % (len(name))
+            self.arrays['dataset'] = np.full(
+                (self._count_for_array_dict(self.arrays)),
+                name, dtype=dataset_dtype)
+
+    @staticmethod
+    def _count_for_array_dict(array_dict):
+        """
+        Return the number of events. Assume that the count of the first element
+        is representative of the whole ttree
+        :param array_dict:
+        :return:
+        """
+        return len(next(iter(array_dict.values())))
+
+    def count(self):
+        """
+        :return:
+        """
+        return self._count_for_array_dict(self.arrays)
+
+    @property
+    def columns(self):
+        return list(self.arrays.keys())
+
+    def _type_for_col(self, col_name):
+        """
+        Interogate the dictionary and extract the dtype for the given column
+        regardless of its underlying implementation
+        :param col_name:
+        :return:
+        """
+        col = self.arrays[col_name]
+
+        if isinstance(col, np.ndarray):
+            return col.dtype.name
+        elif isinstance(col, awk.JaggedArray):
+            return col.content.dtype.name
+        else:
+            return "???"
+
+    @property
+    def columns_with_types(self):
+        return [(col_name, self._type_for_col(col_name)) for col_name in
+                self.columns]
+
+    def show(self):
+        pass
+
+    def repartition(self, num_partitions):
+        pass
+
+    def select_columns(self, columns):
+        pass
+
+    def execute_udf(self, user_func):
+        return user_func.function(self.arrays)

--- a/irishep/datasets/dataset.py
+++ b/irishep/datasets/dataset.py
@@ -133,3 +133,11 @@ class Dataset(metaclass=ABCMeta):
         :param num_partitions: Number of partitions
         :return: None
         """
+
+    @abstractmethod
+    def execute_udf(self, user_func):
+        """
+        Execute the UDF locally
+        :param user_func: Instance of UserFunction to execute
+        :return:
+        """

--- a/irishep/datasets/inmemory_files_dataset_manager.py
+++ b/irishep/datasets/inmemory_files_dataset_manager.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from irishep.datasets.dataset_manager import DatasetManager
+import csv
+
+
+class InMemoryFilesDatasetManager(DatasetManager):
+    """
+    Dataset manager that is backed by a csv file. The file must contain entries
+    for each file associated with datasets.
+
+    The format of the file is:
+    name, path
+    Where "name" is the dataset name, and "path" is the path to the underlying
+    file. Datasets can be made up of multiple files. This is represented by
+    mulitple entries sharing the same name.
+    """
+
+    def __init__(self, database_file):
+        self.database_file = database_file
+        self.provisioned = False
+        self.database = None
+
+    def provision(self, app):
+        """
+        Provision the manager after the app has been set up by reading the csv
+        file and storing the resulting dataframe
+        :param app: The initialized Query Service App
+        :return: None
+        """
+        with open(self.database_file) as f:
+            reader = csv.reader(f, skipinitialspace=True)
+            header = next(reader)
+            self.database = [dict(zip(header, map(str, row))) for row in reader]
+
+        self.provisioned = True
+
+    def get_names(self):
+        """
+        return the names of the datasets in the database
+        :return: list of dataset names
+        """
+        return list(set([x["name"] for x in self.database]))
+
+    def get_file_list(self, dataset_name):
+        """
+        Get paths to the files that make up the given dataset
+        :param dataset_name:
+        :return: List of paths
+        """
+        return [rec["path"] for rec in self.database if
+                rec["name"] == dataset_name]

--- a/irishep/datasets/spark_dataset.py
+++ b/irishep/datasets/spark_dataset.py
@@ -25,79 +25,58 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from irishep.datasets.dataset import Dataset
+# noinspection PyUnresolvedReferences
+from pyspark.sql.functions import lit
 
 
-import re
+class SparkDataset(Dataset):
+    # There is no support in arrow for certain datatypes. Avoid exceptions by
+    # casting the column to a supported datatype
+    pyarrow_column_coverters = {
+        "array<boolean>": lambda col: col.cast("array<int >")
+    }
 
-from abc import ABCMeta, abstractmethod
+    def _pyarrow_compatble_column(self, col, col_type):
+        """
+        Convert the colummn into a cast statement if the column's type is not
+        supported by pyArrow
+        :param col: Column Object
+        :param col_type: Type name as a string
+        :return: Column, or casted column
+        """
+        if col_type in self.pyarrow_column_coverters:
+            return self.pyarrow_column_coverters[col_type](col)
+        else:
+            return col
 
+    def __init__(self, name, dataframe):
+        super().__init__(name)
 
-class Dataset(metaclass=ABCMeta):
+        if 'dataset' not in dataframe.columns:
+            self.dataframe = dataframe.withColumn("dataset", lit(name))
+        else:
+            self.dataframe = dataframe
 
-    def __init__(self, name):
-        self.name = name
-
-    @abstractmethod
     def count(self):
-        """
-
-        :return:
-        """
+        return self.dataframe.count()
 
     @property
-    @abstractmethod
     def columns(self):
         """
         Fetch the list of column names from the dataset
         :return: List of string column names
         """
+        return self.dataframe.columns
 
     @property
-    @abstractmethod
     def columns_with_types(self):
         """
         Fetch the list of column names along with their datatypes
         :return: List of tuples with column name and datatype as string
         """
+        return self.dataframe.dtypes
 
-    def columns_for_physics_objects(self, physics_objects):
-        """
-        Return a list of columns that form part of the requested physics_objects
-        This will include all properties of the pyhsics object, or a count
-        variable associated with the object such as nElectrons
-        :param physics_objects:
-        :return: list of columns
-        """
-        # Create column Names for the count properties (nElectrons, nMuons, etc)
-        physics_obj_count_cols = ["n" + col for col in physics_objects]
-
-        # Join together into a series of alternate REs
-        physics_obj_count_re = "(" + ")|(".join(physics_obj_count_cols) + ")"
-
-        # Create an RE that will match a physics object's properties
-        # i.e. Electon_.*
-        physics_obj_re = "(" + ")|(".join(physics_objects) + ")_.*"
-
-        # Now create a composite RE that will match a count or a
-        # physics obj property
-        r = re.compile(
-            "(" + physics_obj_re + ")|(" + physics_obj_count_re + ")")
-
-        # Filter and return list
-        # noinspection PyTypeChecker
-        return [col for col in self.columns if r.match(col)]
-
-    @staticmethod
-    def count_column_for_physics_object(physics_object):
-        """
-        Generate a column name that represents the count property for a physics
-        object. i.e. nElectron
-        :param physics_object: the name of the physics object
-        :return: Column name for the count of this object
-        """
-        return "n" + physics_object
-
-    @abstractmethod
     def select_columns(self, columns):
         """
         Create a new dataset object that contains only the specified columns.
@@ -108,28 +87,28 @@ class Dataset(metaclass=ABCMeta):
         :param columns: List of column names
         :return: New dataframe with only the requested columns
         """
+        columns2 = set(columns).union(
+            ["dataset", "run", "luminosityBlock", "event"])
 
-    def udf_arguments(self, physics_objects):
-        """
-        Construct the set of argumnents to UDFs on this dataset based on the
-        requested Physics Objects.
-        For now we also include the dataset name column for bookkeeping
-        :param physics_objects: List of physics object names
-        :return: List of colums for passing in as arguments to UDF
-        """
-        return ["dataset"]+self.columns_for_physics_objects(physics_objects)
+        projected = self.dataframe.select(list(columns2))
 
-    @abstractmethod
+        columns3 = [self._pyarrow_compatble_column(projected[c[0]], c[1]) for c
+                    in projected.dtypes]
+
+        return SparkDataset(name=self.name,
+                            dataframe=self.dataframe.select(list(columns3)))
+
     def show(self):
         """
         Print out a friendly representation of the dataframe
         :return: None
         """
+        self.dataframe.show()
 
-    @abstractmethod
     def repartition(self, num_partitions):
         """
         Distribute the dataframe across the given number of partitions
         :param num_partitions: Number of partitions
         :return: None
         """
+        self.dataframe = self.dataframe.repartition(num_partitions)

--- a/irishep/datasets/tests/test_awkward_dataset.py
+++ b/irishep/datasets/tests/test_awkward_dataset.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import Mock
+
+import awkward as awk
+import numpy as np
+
+from irishep.datasets.awkward_dataset import AwkwardDataset
+
+
+class TestAwkwardDataset(unittest.TestCase):
+    def test_init(self):
+        array_dict = {b'Electron': np.zeros((3,))}
+        d = AwkwardDataset("foo", array_dict)
+
+        self.assertEqual("foo", d.name)
+        self.assertTrue("dataset" in d.columns)
+        self.assertTrue("Electron" in d.arrays.keys())
+
+    def test_init_with_existing_dataset(self):
+        array_dict = {b'Electron': np.zeros((3,)), b"dataset": ["a"]}
+        d = AwkwardDataset("foo", array_dict)
+        self.assertTrue("dataset" in d.columns)
+
+    def test_count(self):
+        array_dict = {b'Electron': np.zeros((3,))}
+        d = AwkwardDataset("foo", array_dict)
+        self.assertEqual(3, d.count())
+
+    def test_columns(self):
+        array_dict = {
+            b"nElectron": np.zeros((3,)),
+            b"Electron_pt": np.zeros((3,)),
+            b"Electron_eta": np.zeros((3,)),
+            b"Electron_phi": np.zeros((3,))
+        }
+        d = AwkwardDataset("foo", array_dict)
+        self.assertTrue(sorted(["dataset",
+                                "nElectron",
+                                "Electron_pt",
+                                "Electron_eta",
+                                "Electron_phi",
+                                ]), sorted(d.columns))
+
+    def test_columns_with_types(self):
+        array_dict = {
+            b"nElectron": np.zeros((3,), dtype="float64"),
+            b"Electron_pt": np.zeros((3,), dtype='int16'),
+            b"Electron_eta": awk.JaggedArray.fromiter([[1, 2, 3], [1.0, 3.14]]),
+            b"Electron_phi": [1, 2, 3]
+        }
+
+        d = AwkwardDataset("foo", array_dict)
+        array_dict = {col_name: dtype for (col_name, dtype) in
+                      d.columns_with_types}
+        self.assertEqual("float64", array_dict["nElectron"])
+        self.assertEqual("int16", array_dict["Electron_pt"])
+        self.assertEqual("???", array_dict["Electron_phi"])
+        self.assertEqual("float64", array_dict["Electron_eta"])
+
+    @staticmethod
+    def _create_test_dataframe():
+        return AwkwardDataset("foo", {b'Electron': np.zeros((3,))})
+
+    def test_show(self):
+        self._create_test_dataframe().show()
+
+    def test_repartition(self):
+        self._create_test_dataframe().repartition(42)
+
+    def test_select_columns(self):
+        self._create_test_dataframe().select_columns([])
+
+    def test_execute_udf(self):
+        udf = Mock()
+        udf.function = Mock()
+
+        df = self._create_test_dataframe()
+        df.execute_udf(udf)
+        udf.function.assert_called_with(df.arrays)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/irishep/datasets/tests/test_inmemory_files_dataset_manager.py
+++ b/irishep/datasets/tests/test_inmemory_files_dataset_manager.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from irishep.datasets.inmemory_files_dataset_manager import \
+    InMemoryFilesDatasetManager
+
+
+class TestInmemoryFilesDataset(unittest.TestCase):
+    @staticmethod
+    def _mock_open(*args, **kargs):
+        f_open = unittest.mock.mock_open(*args, **kargs)
+        f_open.return_value.__iter__ = lambda vals: iter(vals.readline, '')
+        return f_open
+
+    def _init_database(self, dsm, import_db):
+        mock_app = MagicMock()
+
+        with patch("builtins.open",
+                   self._mock_open(read_data=import_db)):
+            dsm.provision(mock_app)
+
+    def test_init_database(self):
+        dsm = InMemoryFilesDatasetManager("/foo/bar")
+        self.assertFalse(dsm.provisioned)
+        self.assertEqual(dsm.database_file, "/foo/bar")
+        mock_app = MagicMock()
+
+        with patch("builtins.open", self._mock_open(
+                read_data="name,path\nfoo,/tmp/bar\nbaz,/usr/bob")) \
+                as mock_datafile:
+            dsm.provision(mock_app)
+            mock_datafile.assert_called_with("/foo/bar")
+
+            self.assertEqual(2, len(dsm.database))
+            self.assertEqual(dsm.database[0]["name"], "foo")
+            self.assertEqual(dsm.database[0]["path"], "/tmp/bar")
+            self.assertEqual(dsm.database[1]["name"], "baz")
+            self.assertEqual(dsm.database[1]["path"], "/usr/bob")
+
+            self.assertTrue(dsm.provisioned)
+
+    def test_get_names(self):
+        dsm = InMemoryFilesDatasetManager("/foo/bar")
+        self._init_database(dsm, "\n".join(
+            ["name,path", "foo,/tmp/bar", "baz,/usr/bob", "baz,/usr/bob2"]))
+
+        self.assertEqual(sorted(['foo', 'baz']), sorted(dsm.get_names()))
+
+    def test_get_files(self):
+        dsm = InMemoryFilesDatasetManager("/foo/bar")
+        self._init_database(dsm, "\n".join(
+            ["name,path", "foo,/tmp/bar", "baz,/usr/bob", "baz,/usr/bob2"]))
+
+        self.assertEqual(['/tmp/bar'], dsm.get_file_list('foo'))
+        self.assertEqual(['/usr/bob', '/usr/bob2'], dsm.get_file_list('baz'))

--- a/irishep/datasets/tests/test_spark_dataset.py
+++ b/irishep/datasets/tests/test_spark_dataset.py
@@ -1,10 +1,10 @@
 import unittest
 from unittest.mock import Mock, patch, MagicMock
 import pyspark.sql
-from irishep.datasets.dataset import Dataset
+from irishep.datasets.spark_dataset import SparkDataset
 
 
-class TestDataset(unittest.TestCase):
+class TestSparkDataset(unittest.TestCase):
     @staticmethod
     def _generate_mock_dataframe():
         mock_dataframe = MagicMock(pyspark.sql.DataFrame)
@@ -29,20 +29,20 @@ class TestDataset(unittest.TestCase):
             mock_dataframe = self._generate_mock_dataframe()
             mock_dataframe.columns = ['run', 'event']
             mock_dataframe.withColumn = Mock(return_value=mock_dataframe)
-            a_dataset = Dataset("my dataset", mock_dataframe)
+            a_dataset = SparkDataset("my dataset", mock_dataframe)
             self.assertEqual(a_dataset.name, "my dataset")
             self.assertEqual(a_dataset.dataframe, mock_dataframe)
 
     def test_constuctor_with_dataset_name_in_dataframe(self):
         mock_dataframe = self._generate_mock_dataframe()
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
         self.assertEqual(a_dataset.name, "my dataset")
         self.assertEqual(a_dataset.dataframe, mock_dataframe)
 
     def test_count(self):
         mock_dataframe = self._generate_mock_dataframe()
         mock_dataframe.count = Mock(return_value=42)
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
         count = a_dataset.count()
         self.assertEqual(42, count)
         mock_dataframe.count.assert_called_once()
@@ -50,14 +50,14 @@ class TestDataset(unittest.TestCase):
     def test_columns(self):
         mock_dataframe = self._generate_mock_dataframe()
         mock_dataframe.columns = ['dataset', 'a', 'b', 'c']
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
         cols = a_dataset.columns
         self.assertEqual(cols, ['dataset', 'a', 'b', 'c'])
 
     def test_columns_with_types(self):
         mock_dataframe = self._generate_mock_dataframe()
         mock_dataframe.dtypes = [('a', 'int'), ('b', 'string')]
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
         cols = a_dataset.columns_with_types
         self.assertEqual(cols, [('a', 'int'), ('b', 'string')])
 
@@ -66,7 +66,7 @@ class TestDataset(unittest.TestCase):
         mock_dataframe.columns = ["dataset", "run", "luminosityBlock", "event",
                                   "nElectrons", "Electron_pt", "Electron_eta",
                                   "nMuons", "Muon_pt", "Muon_eta"]
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
         rslt = a_dataset.columns_for_physics_objects(["Electron", "Muon"])
         self.assertEqual(rslt,
                          ['nElectrons', 'Electron_pt', 'Electron_eta', 'nMuons',
@@ -74,7 +74,7 @@ class TestDataset(unittest.TestCase):
 
     def test_count_column_for_physics_object(self):
         mock_dataframe = self._generate_mock_dataframe()
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
         self.assertEqual("nElectron",
                          a_dataset.count_column_for_physics_object("Electron"))
 
@@ -85,7 +85,7 @@ class TestDataset(unittest.TestCase):
         mock_dataframe2 = self._generate_mock_dataframe()
         mock_dataframe.select = Mock(return_value=mock_dataframe2)
 
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
 
         a_dataset2 = a_dataset.select_columns(
             ["dataset", "run", "luminosityBlock", "event", "Electron_pt"])
@@ -124,7 +124,7 @@ class TestDataset(unittest.TestCase):
 
         mock_dataframe.select = Mock(return_value=mock_dataframe2)
 
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
 
         a_dataset2 = a_dataset.select_columns(
             ["dataset", "run", "luminosityBlock", "event", "Muon_tightId"])
@@ -147,7 +147,7 @@ class TestDataset(unittest.TestCase):
 
         mock_dataframe.select = Mock(return_value=mock_dataframe2)
 
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
         a_dataset2 = a_dataset.select_columns(["Electron_pt"])
 
         self.assertEqual(mock_dataframe2, a_dataset2.dataframe)
@@ -165,7 +165,7 @@ class TestDataset(unittest.TestCase):
         mock_dataframe.columns = ["dataset", "run", "luminosityBlock", "event",
                                   "nElectrons", "Electron_pt", "Electron_eta",
                                   "nMuons", "Muon_pt", "Muon_eta"]
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
         result = a_dataset.udf_arguments(["Electron"])
         self.assertEqual(
             ['dataset', 'nElectrons', 'Electron_pt', 'Electron_eta'], result)
@@ -173,7 +173,7 @@ class TestDataset(unittest.TestCase):
     def test_show(self):
         mock_dataframe = self._generate_mock_dataframe()
         mock_dataframe.show = Mock()
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
         a_dataset.show()
 
         mock_dataframe.show.assert_called_once()
@@ -181,7 +181,7 @@ class TestDataset(unittest.TestCase):
     def test_repartition(self):
         mock_dataframe = self._generate_mock_dataframe()
         mock_dataframe.repartition = Mock()
-        a_dataset = Dataset("my dataset", mock_dataframe)
+        a_dataset = SparkDataset("my dataset", mock_dataframe)
 
         a_dataset.repartition(42)
         mock_dataframe.repartition.assert_called_with(42)

--- a/irishep/datasets/tests/test_uproot_dataset.py
+++ b/irishep/datasets/tests/test_uproot_dataset.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import unittest
+from unittest.mock import Mock, patch
+
+from irishep.datasets.awkward_dataset import AwkwardDataset
+from irishep.datasets.uproot_dataset import UprootDataset
+
+
+class TestUprootDataset(unittest.TestCase):
+    def test_init(self):
+        ttree = Mock()
+        d = UprootDataset("foo", ttree)
+        self.assertEqual(d.name, "foo")
+        self.assertEqual(d.ttree, ttree)
+
+    def test_count(self):
+        ttree = [1, 2, 3]
+        d = UprootDataset("foo", ttree)
+        self.assertEqual(3, d.count())
+
+    def test_columns(self):
+        ttree = {b'a': 1, b'b': 2, b'c': 3}
+        d = UprootDataset("foo", ttree)
+        cols = d.columns
+        self.assertEqual(["a", "b", "c"], cols)
+
+    def test_select_colmns(self):
+        ttree = Mock()
+        ttree.arrays = Mock(return_value=[1, 2, 3])
+        with patch("irishep.datasets.awkward_dataset.AwkwardDataset.__init__",
+                   return_value=None) as awk_dataset:
+            d = UprootDataset("foo", ttree)
+            d2 = d.select_columns(["a", "b", "c"])
+            awk_dataset.assert_called_with("foo", [1, 2, 3])
+            self.assertIsInstance(d2, AwkwardDataset)
+
+    def test_columns_with_types(self):
+        d = UprootDataset("foo", [1, 2, 3])
+
+        with self.assertRaises(NotImplementedError):
+            # noinspection PyStatementEffect
+            d.columns_with_types
+
+    def test_show(self):
+        d = UprootDataset("foo", [1, 2, 3])
+
+        with self.assertRaises(NotImplementedError):
+            d.show()
+
+    def test_repartition(self):
+        d = UprootDataset("foo", [1, 2, 3])
+
+        with self.assertRaises(NotImplementedError):
+            d.repartition(43)
+
+    def test_execute_udf(self):
+        d = UprootDataset("foo", [1, 2, 3])
+
+        with self.assertRaises(NotImplementedError):
+            d.execute_udf(43)

--- a/irishep/datasets/uproot_dataset.py
+++ b/irishep/datasets/uproot_dataset.py
@@ -25,45 +25,34 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from pyspark.sql import SparkSession
-
-from irishep.datasets.spark_dataset import SparkDataset
-from irishep.executors.executor import Executor
+from irishep.datasets.awkward_dataset import AwkwardDataset
+from irishep.datasets.dataset import Dataset
 
 
-class SparkExecutor(Executor):
-    templates = {
-        "nanoAOD": "mytemplate.py"
-    }
+class UprootDataset(Dataset):
+    def __init__(self, name, ttree):
+        super().__init__(name)
+        self.ttree = ttree
 
-    def __init__(self, master, app_name, num_partitions):
-        super().__init__(app_name)
-        self.spark = SparkSession.builder \
-            .master(master) \
-            .appName(app_name) \
-            .config("spark.jars.packages",
-                    "org.diana-hep:spark-root_2.11:0.1.15") \
-            .getOrCreate()
-        self.num_partitions = num_partitions
+    def select_columns(self, columns):
+        return AwkwardDataset(self.name, self.ttree.arrays(columns))
 
-    def read_files(self, dataset_name, files):
-        result_df = None
-        # Sparkroot can't handle list of files
-        for file in files:
-            file_df = self.spark.read.format("org.dianahep.sparkroot") \
-                .option("tree", "Events") \
-                .load(file)
+    def count(self):
+        return len(self.ttree)
 
-            # So just append each file's datafrane into one big one
-            result_df = file_df if not result_df else result_df.union(file_df)
+    @property
+    def columns_with_types(self):
+        raise NotImplementedError()
 
-        dataset = SparkDataset(dataset_name, result_df)
-        dataset.repartition(self.num_partitions)
+    def show(self):
+        raise NotImplementedError
 
-        return dataset
+    @property
+    def columns(self):
+        return [branch.decode("utf-8") for branch in self.ttree.keys()]
 
-    def register_accumulator(self, initial_value, accumulator):
-        return self.spark.sparkContext.accumulator(initial_value, accumulator)
+    def repartition(self, num_partitions):
+        raise NotImplementedError
 
-    def register_broadcast_var(self, var):
-        return self.spark.sparkContext.broadcast(var)
+    def execute_udf(self, user_func):
+        raise NotImplementedError

--- a/irishep/executors/__init__.py
+++ b/irishep/executors/__init__.py
@@ -25,34 +25,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-class App:
-    def __init__(self, config):
-        self.config = config
-        self.executor = config.executor
-        self.dataset_manager = config.dataset_manager
-
-    @property
-    def datasets(self):
-        """
-        Fetch an initialized dataset manager instance
-        :return: the dataset manager instance
-        """
-        if not self.dataset_manager.provisioned:
-            self.dataset_manager.provision(self)
-        return self.dataset_manager
-
-    def read_dataset(self, dataset_name):
-        """
-        Creates a dataset from files on disk. For now assumes that the files are
-        in ROOT format
-        :param dataset_name: Name of the dataset to read. Gets filenames from
-            the dataset_manager
-        :return: A populated Dataset instance
-        """
-        files = self.datasets.get_file_list(dataset_name)
-        print(files)
-
-        dataset = self.executor.read_files(dataset_name, files)
-        return dataset

--- a/irishep/executors/executor.py
+++ b/irishep/executors/executor.py
@@ -25,34 +25,35 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from abc import ABCMeta, abstractmethod
 
 
-class App:
-    def __init__(self, config):
-        self.config = config
-        self.executor = config.executor
-        self.dataset_manager = config.dataset_manager
+class Executor(metaclass=ABCMeta):
+    def __init__(self, app_name):
+        self.app_name = app_name
 
-    @property
-    def datasets(self):
+    @abstractmethod
+    def read_files(self, dataset_name, files):
         """
-        Fetch an initialized dataset manager instance
-        :return: the dataset manager instance
-        """
-        if not self.dataset_manager.provisioned:
-            self.dataset_manager.provision(self)
-        return self.dataset_manager
 
-    def read_dataset(self, dataset_name):
+        :param dataset_name:
+        :param files:
+        :return:
         """
-        Creates a dataset from files on disk. For now assumes that the files are
-        in ROOT format
-        :param dataset_name: Name of the dataset to read. Gets filenames from
-            the dataset_manager
-        :return: A populated Dataset instance
-        """
-        files = self.datasets.get_file_list(dataset_name)
-        print(files)
 
-        dataset = self.executor.read_files(dataset_name, files)
-        return dataset
+    @abstractmethod
+    def register_accumulator(self, initial_value, accumulator):
+        """
+
+        :param initial_value:
+        :param accumulator:
+        :return:
+        """
+
+    @abstractmethod
+    def register_broadcast_var(self, value):
+        """
+
+        :param value:
+        :return:
+        """

--- a/irishep/executors/tests/__init__.py
+++ b/irishep/executors/tests/__init__.py
@@ -25,34 +25,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-class App:
-    def __init__(self, config):
-        self.config = config
-        self.executor = config.executor
-        self.dataset_manager = config.dataset_manager
-
-    @property
-    def datasets(self):
-        """
-        Fetch an initialized dataset manager instance
-        :return: the dataset manager instance
-        """
-        if not self.dataset_manager.provisioned:
-            self.dataset_manager.provision(self)
-        return self.dataset_manager
-
-    def read_dataset(self, dataset_name):
-        """
-        Creates a dataset from files on disk. For now assumes that the files are
-        in ROOT format
-        :param dataset_name: Name of the dataset to read. Gets filenames from
-            the dataset_manager
-        :return: A populated Dataset instance
-        """
-        files = self.datasets.get_file_list(dataset_name)
-        print(files)
-
-        dataset = self.executor.read_files(dataset_name, files)
-        return dataset

--- a/irishep/executors/tests/test_spark_executor.py
+++ b/irishep/executors/tests/test_spark_executor.py
@@ -1,0 +1,101 @@
+import unittest
+from unittest.mock import patch, Mock, MagicMock, call
+
+import pyspark.sql
+from pyspark.sql import SparkSession
+
+from irishep.executors.spark_executor import SparkExecutor
+
+
+class TestSparkExecutor(unittest.TestCase):
+    @staticmethod
+    def _construct_exector():
+        builder = pyspark.sql.session.SparkSession.Builder()
+        mock_session = MagicMock(SparkSession)
+
+        builder.master = Mock(return_value=builder)
+        builder.appName = Mock(return_value=builder)
+        builder.getOrCreate = Mock(return_value=mock_session)
+
+        with patch('pyspark.sql.SparkSession.builder', new=builder):
+            e = SparkExecutor(app_name="foo",
+                              master="spark-master", num_partitions=42)
+
+            return e
+
+    def test_init(self):
+        builder = pyspark.sql.session.SparkSession.Builder()
+        mock_session = MagicMock(SparkSession)
+
+        builder.master = Mock(return_value=builder)
+        builder.appName = Mock(return_value=builder)
+        builder.getOrCreate = Mock(return_value=mock_session)
+
+        with patch('pyspark.sql.SparkSession.builder', new=builder):
+            e = SparkExecutor(app_name="foo",
+                              master="spark-master", num_partitions=42)
+
+            assert e
+            builder.master.assert_called_with("spark-master")
+            builder.appName.assert_called_with("foo")
+            builder.getOrCreate.assert_called_once()
+            self.assertEqual(e.spark, mock_session)
+
+    def test_read_files(self):
+        executor = self._construct_exector()
+
+        # There will be dataframes generated for each file as part of the load
+        mock_file_dataframes = [Mock(pyspark.sql.DataFrame),
+                                Mock(pyspark.sql.DataFrame)]
+        executor.spark.read.format = Mock(return_value=executor.spark)
+        executor.spark.option = Mock(return_value=executor.spark)
+        executor.spark.load = Mock(side_effect=mock_file_dataframes)
+
+        # The first dataframe will be union'ed with the second, resulting in a
+        # new dataframe
+        mock_union_dataframe = Mock(pyspark.sql.DataFrame)
+        mock_union_dataframe.columns = ['dataset', 'a', 'b']
+        mock_file_dataframes[0].union = Mock(return_value=mock_union_dataframe)
+        mock_union_dataframe.repartition = Mock(
+            return_value=mock_union_dataframe)
+
+        # Perform the read
+        dataset = executor.read_files("mydataset",
+                                      ["/tmp/foo.root", "/tmp/bar.root"])
+
+        executor.spark.read.format.assert_called_with("org.dianahep.sparkroot")
+
+        executor.spark.load.assert_has_calls(
+            [call("/tmp/foo.root"), call("/tmp/bar.root")])
+
+        self.assertEqual(dataset.name, "mydataset")
+        self.assertEqual(dataset.dataframe, mock_union_dataframe)
+
+        # Verify that the first file's dataframe was unioned with the
+        # second file
+        mock_file_dataframes[0].union.assert_called_with(
+            mock_file_dataframes[1])
+
+        # Verify that the resulting dataframe was repartitioned
+        mock_union_dataframe.repartition.assert_called_with(42)
+
+    def test_register_accumulator(self):
+        executor = self._construct_exector()
+        mock_accumulator = Mock()
+        executor.spark.sparkContext.accumulator = Mock()
+        executor.register_accumulator("init", mock_accumulator)
+        executor.\
+            spark.sparkContext.\
+            accumulator.assert_called_with("init", mock_accumulator)
+
+    def test_register_broadcast_var(self):
+        executor = self._construct_exector()
+        executor.spark.sparkContext.broadcast = Mock()
+        executor.register_broadcast_var("myVar")
+        executor.\
+            spark.sparkContext.\
+            broadcast.assert_called_with("myVar")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/irishep/executors/tests/test_uproot_executor.py
+++ b/irishep/executors/tests/test_uproot_executor.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from irishep.executors.uproot_executor import UprootExecutor
+
+
+class TestUprootExecutor(unittest.TestCase):
+    def test_init(self):
+        e = UprootExecutor("foo")
+        self.assertEqual(e.app_name, "foo")
+
+    def test_read_files(self):
+        e = UprootExecutor("e")
+
+        with patch("uproot.open",
+                   return_value={"Events": "test"}) as uproot_mock:
+            d = e.read_files("bar", ["/tmp/baz.root"])
+            uproot_mock.assert_called_with("/tmp/baz.root")
+            self.assertEqual("bar", d.name)
+            self.assertEqual("test", d.ttree)
+
+    def test_read_files_multiple(self):
+        e = UprootExecutor("e")
+
+        with patch("uproot.open") as uproot_mock:
+            e.read_files("bar", ["/tmp/baz.root", "/tmp/bat.root"])
+            uproot_mock.assert_called_with("/tmp/baz.root")
+
+    def test_register_accumulator(self):
+        e = UprootExecutor("e")
+        mock_accum = Mock()
+        mock_accum.addInPlace = Mock(return_value="xxx")
+        a = e.register_accumulator("val", mock_accum)
+        self.assertEqual("val", a.value)
+        self.assertEqual(mock_accum, a.accumulator)
+
+        a.add("yyy")
+        mock_accum.addInPlace.assert_called_with("val", "yyy")
+        self.assertEqual("xxx", a.value)
+
+    def test_register_broadcast_var(self):
+        e = UprootExecutor("e")
+        b = e.register_broadcast_var("hi")
+        self.assertEqual("hi", b.value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/irishep/templates/mytemplate.py
+++ b/irishep/templates/mytemplate.py
@@ -8,9 +8,8 @@ def udf({% for col in cols %}{{col}}{{ "," if not loop.last }}{% endfor %}):
     {% for obj in physics_objects.keys() %}
     physics_objects["{{obj}}"] = \
         JaggedCandidateArray.candidatesfromcounts(
-            {% for zip_entry in physics_objects.get(obj) %}{{zip_entry}}{{ "," if not loop.last }}
-            {% endfor %})
+            {{counts[obj]}}.values, {% for column in physics_objects[obj] %}
+            {{column['physics_obj_property']}}={{column['col']}}.array[0].base {{ "," if not loop.last }}{% endfor %})
     {% endfor %}
 
-    my_analysis.calc(physics_objects, dataset[0])
-    return {{return_expr}}
+    return pd.Series(my_analysis.calc(physics_objects, dataset[0]))

--- a/irishep/templates/uproot_nanoaod.py
+++ b/irishep/templates/uproot_nanoaod.py
@@ -1,0 +1,14 @@
+def udf(arrays):
+    import pandas as pd
+    import numpy as np
+    from fnal_column_analysis_tools.analysis_objects import JaggedCandidateArray
+    global my_analysis
+
+    physics_objects = {}
+    {% for obj in physics_objects.keys() %}
+    physics_objects["{{obj}}"] = \
+        JaggedCandidateArray.candidatesfromcounts(arrays['{{counts[obj]}}'], {% for column in physics_objects[obj] %}
+            {{column['physics_obj_property']}}=arrays["{{column['col']}}"].content {{ "," if not loop.last }}{% endfor %})
+    {% endfor %}
+
+    return my_analysis.calc(physics_objects, arrays["dataset"][0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+numpy==1.16.1
+awkward>=0.8.4
+uproot>=3.4.5
 pyspark==2.4.0
 coverage==4.5.2
 codecov==2.0.15


### PR DESCRIPTION
# Problem
Fixes #20 
For testing and development it's much more convenient to run an analysis locally using uproot instead of in spark. We need a way to run the exact same code on spark as locally with just a config change.

#Approach
Pulled the spark-specific stuff into a new class called an `Executor` which is set at config time. Created a new dataset based on uproot reader. Made the `select_columns` method gather up the dictionary of nested arrays and generated a native `JaggedArray` dictionary. This becomes a new dataset subclass, `AwkwardDataset`

The UDFs operate on the AwkwardDataset.

The `FileDatasetManager` depended on an instance of spark for querying datasets. Made a new subclass which just keeps the dataset definitions in a python dictionary.